### PR TITLE
Add Seam definition to glossary

### DIFF
--- a/foundations/glossary.md
+++ b/foundations/glossary.md
@@ -79,8 +79,6 @@ class OrderService:
 
 A seam always has an *enabling point*: the place where you choose which behaviour to use. In the example above, the enabling point is the constructor parameter.
 
----
-
 **Composition Root**
 The single place in an application where all dependencies are wired together. Instead of creating objects throughout the codebase, everything is assembled once at startup. This keeps dependency creation out of business logic and makes the structure of the application easy to see and change in one place.
 

--- a/foundations/glossary.md
+++ b/foundations/glossary.md
@@ -58,6 +58,29 @@ def transfer(amount):
 
 ---
 
+**Seam**
+A seam is a place in the code where behaviour can be changed without modifying the code at that point. The term comes from Michael Feathers' *Working Effectively with Legacy Code*. Seams are the basis for making existing code testable: instead of calling a concrete dependency directly, the code is structured so a different implementation can be substituted at the seam — typically through dependency injection, an interface, or a configuration point.
+
+```python
+# No seam — the dependency is created internally; cannot be replaced in tests.
+class OrderService:
+    def place_order(self, order):
+        mailer = SmtpMailer()  # hard-coded; no way to substitute
+        mailer.send(order.confirmation_email())
+
+# Object seam — the dependency is injected; a test double can be passed in.
+class OrderService:
+    def __init__(self, mailer: Mailer):
+        self.mailer = mailer
+
+    def place_order(self, order):
+        self.mailer.send(order.confirmation_email())
+```
+
+A seam always has an *enabling point*: the place where you choose which behaviour to use. In the example above, the enabling point is the constructor parameter.
+
+---
+
 **Composition Root**
 The single place in an application where all dependencies are wired together. Instead of creating objects throughout the codebase, everything is assembled once at startup. This keeps dependency creation out of business logic and makes the structure of the application easy to see and change in one place.
 

--- a/foundations/glossary.md
+++ b/foundations/glossary.md
@@ -59,7 +59,7 @@ def transfer(amount):
 ---
 
 **Seam**
-A seam is a place in the code where behaviour can be changed without modifying the code at that point. Seams are the basis for making existing code testable: instead of calling a concrete dependency directly, the code is structured so a different implementation can be substituted at the seam — typically through dependency injection, an interface, or a configuration point.
+A seam is a place in the code where behaviour can be changed without modifying the code at that point. Seams are the basis for making existing code testable: instead of calling a concrete dependency directly, the code is structured so a different implementation can be substituted at the seam, typically through dependency injection, an interface, or a configuration point.
 
 ```python
 # No seam — the dependency is created internally; cannot be replaced in tests.
@@ -78,6 +78,8 @@ class OrderService:
 ```
 
 A seam always has an *enabling point*: the place where you choose which behaviour to use. In the example above, the enabling point is the constructor parameter.
+
+---
 
 **Composition Root**
 The single place in an application where all dependencies are wired together. Instead of creating objects throughout the codebase, everything is assembled once at startup. This keeps dependency creation out of business logic and makes the structure of the application easy to see and change in one place.

--- a/foundations/glossary.md
+++ b/foundations/glossary.md
@@ -59,7 +59,7 @@ def transfer(amount):
 ---
 
 **Seam**
-A seam is a place in the code where behaviour can be changed without modifying the code at that point. The term comes from Michael Feathers' *Working Effectively with Legacy Code*. Seams are the basis for making existing code testable: instead of calling a concrete dependency directly, the code is structured so a different implementation can be substituted at the seam — typically through dependency injection, an interface, or a configuration point.
+A seam is a place in the code where behaviour can be changed without modifying the code at that point. Seams are the basis for making existing code testable: instead of calling a concrete dependency directly, the code is structured so a different implementation can be substituted at the seam — typically through dependency injection, an interface, or a configuration point.
 
 ```python
 # No seam — the dependency is created internally; cannot be replaced in tests.


### PR DESCRIPTION
## Summary
Added a new glossary entry for "Seam" to the foundations documentation, explaining this important concept from Michael Feathers' *Working Effectively with Legacy Code*.

## Key Changes
- Added comprehensive definition of seams as places in code where behavior can be changed without modifying the code at that point
- Included practical Python examples demonstrating:
  - An anti-pattern showing hard-coded dependencies that cannot be replaced in tests
  - A seam implementation using dependency injection through constructor parameters
- Explained the concept of an "enabling point" — the location where you choose which behavior to use
- Positioned the entry between the "Transfer" and "Composition Root" glossary entries

## Notable Details
The entry emphasizes the practical testing benefits of seams, showing how they enable the substitution of test doubles and make legacy code more testable without modifying the original code at the seam point.

https://claude.ai/code/session_01Mn8r94wGi4Zsi4uavdCo6A