### PR TITLE
docs: unify section headings and tighten prose punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 ## Purpose and scope
-A compact reference on software architecture — concepts, trade-offs, and structural decisions.
+A compact reference on software architecture: concepts, trade-offs, and structural decisions.
 
 
 ## Table of contents

--- a/architect-role/adr.md
+++ b/architect-role/adr.md
@@ -66,7 +66,7 @@ Use an event bus (Kafka) for asynchronous communication between services.
 - Common convention: `docs/decisions/ADR-NNN-title.md`
 - Tools like [adr-tools](https://github.com/npryce/adr-tools) can automate file creation.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - ADRs add upfront writing effort but reduce long-term confusion and re-discussion.
 - Storing ADRs in the repo keeps them versioned; a wiki is more discoverable but can drift.
 - Teams without ADRs tend to revisit the same architectural debates months or years later.

--- a/architect-role/risk-analysis.md
+++ b/architect-role/risk-analysis.md
@@ -1,7 +1,7 @@
 # Risk Analysis
 
 ## Overview
-Identifying risks early allows architects to address them before they become costly. Risk analysis is a proactive practice — not a reaction to failures.
+Identifying risks early allows architects to address them before they become costly. Risk analysis is a proactive practice, not a reaction to failures.
 
 ## Core concepts
 
@@ -34,7 +34,7 @@ Risk storming works best with a diverse group: developers, ops, product, and sec
 - **Transfer**: shift responsibility (e.g., use a managed service, insurance).
 - **Avoid**: change the design to eliminate the risk entirely.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - Thorough risk analysis takes time but prevents expensive surprises late in delivery.
 - Overengineering mitigations for low-probability risks wastes capacity.
 - Risk storming requires psychological safety. participants must feel comfortable raising concerns.

--- a/architect-role/stakeholder-management.md
+++ b/architect-role/stakeholder-management.md
@@ -29,7 +29,7 @@ Each stakeholder has quality attribute priorities that may conflict. The archite
 ### Build ongoing relationships
 Stakeholder management is continuous, not a one-time activity. Regular check-ins prevent surprises and build alignment over time.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - Over-involving stakeholders slows decisions; under-involving them causes rework.
 - Transparency about trade-offs builds trust but may increase scrutiny.
 - Prioritizing one stakeholder group risks alienating others.

--- a/architect-role/team-alignment.md
+++ b/architect-role/team-alignment.md
@@ -27,7 +27,7 @@ A shared glossary reduces misunderstandings across teams. Define key terms expli
 - Make it easy for teams to raise concerns or propose changes.
 - Treat misalignment as a signal that communication or documentation needs improvement.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - More alignment processes add overhead; too little leads to divergence.
 - Central control keeps systems coherent but reduces team ownership.
 - Written documentation scales better than verbal alignment but can go stale.

--- a/architecture-communication/index.md
+++ b/architecture-communication/index.md
@@ -11,7 +11,7 @@ Architecture only works if it is understood. Clear communication aligns teams, r
 - Living documentation: keep diagrams close to code and update with changes.
 - Adapt to context: the level of documentation should match the complexity and needs of the project.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - More detail improves accuracy but increases maintenance cost.
 - Async docs scale better; live walkthroughs improve shared understanding.
 - Diagram choice should match the question, not the tool.

--- a/architecture-metrics/fitness-functions.md
+++ b/architecture-metrics/fitness-functions.md
@@ -7,7 +7,7 @@ A fitness function is an automated check that verifies whether the system still 
 
 | Property | Description |
 |---|---|
-| Automated | Run without human intervention — typically in CI |
+| Automated | Run without human intervention, typically in CI |
 | Objective | Produce a clear pass/fail result |
 | Targeted | Each function checks one specific architectural concern |
 | Living | Evolve alongside the system as requirements change |
@@ -29,7 +29,7 @@ A fitness function is an automated check that verifies whether the system still 
 
 ---
 
-## Example 1 — Module boundary enforcement (Python / pytest)
+## Example 1: Module boundary enforcement (Python / pytest)
 
 This fitness function prevents modules from crossing architectural boundaries. The rule: nothing inside `src/orders/` may import directly from `src/payments/`. The two domains must communicate only through a defined interface.
 
@@ -68,7 +68,7 @@ If a developer adds `from payments.refunds import calculate_refund` inside the o
 
 ---
 
-## Example 2 — Response-time threshold (Python / pytest)
+## Example 2: Response-time threshold (Python / pytest)
 
 This fitness function runs against a deployed staging environment and fails if the 95th-percentile latency of a critical endpoint exceeds 200 ms.
 
@@ -111,10 +111,10 @@ This makes a regression visible the moment it is deployed to staging, long befor
 ## Relation to other practices
 
 - **ADRs**: Write an ADR to record *why* a constraint exists; write a fitness function to *enforce* it automatically.
-- **Quality attributes**: Fitness functions are the operational expression of quality attribute requirements — they translate "the system must be fast" into a concrete, measurable check.
+- **Quality attributes**: Fitness functions are the operational expression of quality attribute requirements: they translate "the system must be fast" into a concrete, measurable check.
 - **Evolutionary architecture**: Fitness functions are the core mechanism that allows architecture to evolve safely. Teams can refactor freely as long as all fitness functions stay green.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - Fitness functions add maintenance cost: they must be updated when thresholds or rules change intentionally.
-- A failing fitness function that blocks the build is generally more effective than one that only warns — a warning that no one acts on provides little value.
+- A failing fitness function that blocks the build is generally more effective than one that only warns. A warning that no one acts on provides little value.
 - Start with the most critical constraints (security, core module boundaries) and add more as violations occur.

--- a/architecture-patterns/event-driven.md
+++ b/architecture-patterns/event-driven.md
@@ -53,8 +53,8 @@ flowchart LR
 
 | | Broker | Mediator |
 |---|---|---|
-| Coordination | Decentralized — consumers decide what to do | Centralized — mediator controls the flow |
-| Coupling | Low — producer and consumer don't know each other | Medium — mediator knows all steps |
+| Coordination | Decentralized: consumers decide what to do | Centralized: mediator controls the flow |
+| Coupling | Low: producer and consumer don't know each other | Medium: mediator knows all steps |
 | Visibility | Harder to see end-to-end flow | Flow is explicit and auditable in one place |
 | Use when | Fan-out, independent reactions, scalability | Multi-step workflows, ordered processing, error handling across steps |
 
@@ -87,14 +87,14 @@ flowchart TB
 - **Integration events**: events shared across service boundaries. Require stable contracts.
 - **Commands via messaging**: instructions targeted at a specific service. Less decoupled than events.
 
-## Decision considerations / trade-offs
+## Trade-offs
 | | Pro | Con |
 |---|---|---|
 | Decoupling | Producer and consumer deploy independently | Harder to trace end-to-end request flows |
 | Scalability | Consumers scale independently | Event ordering and deduplication require careful design |
 | Resilience | Broker buffers events if consumer is temporarily down | Broker becomes a critical dependency |
 | Auditability | Event log is a natural audit trail | Event schema changes require versioning strategy |
-| Flexibility | Add new consumers without touching producers | Eventual consistency — consumers lag behind producers |
+| Flexibility | Add new consumers without touching producers | Eventual consistency: consumers lag behind producers |
 
 ## When to use / when not to use
 - **Use when**: multiple services react to the same trigger (fan-out).
@@ -105,7 +105,7 @@ flowchart TB
 - **Avoid when**: the team has no tooling to trace events across services or handle failed events.
 - **Avoid when**: eventual consistency is unacceptable for a given operation.
 
-## Practical examples
+## Examples
 - `Orders` publishes `OrderPlaced`; `Billing`, `Inventory`, and `Notifications` each consume it independently.
 - `PaymentService` publishes `PaymentFailed`; a retry workflow is triggered by a consumer.
 - Event log in Kafka used to rebuild read models (projections) for analytics.

--- a/architecture-patterns/hexagonal.md
+++ b/architecture-patterns/hexagonal.md
@@ -1,7 +1,7 @@
 # Hexagonal Architecture (Ports & Adapters)
 
 ## Overview
-Hexagonal architecture isolates core business logic from all external systems — databases, UIs, message brokers, third-party APIs. The core defines *ports* (interfaces), and *adapters* implement those interfaces for specific technologies.
+Hexagonal architecture isolates core business logic from all external systems: databases, UIs, message brokers, third-party APIs. The core defines *ports* (interfaces), and *adapters* implement those interfaces for specific technologies.
 
 This allows the core to be tested and evolved without touching infrastructure, and infrastructure to be swapped without touching the core.
 
@@ -27,8 +27,8 @@ flowchart LR
   AppService -->|"Output Port\n(interface)"| Out
 ```
 
-**Driving adapters** (left): call the core — HTTP controllers, CLI commands, test suites.
-**Driven adapters** (right): called by the core — database, email, external APIs.
+**Driving adapters** (left): call the core (HTTP controllers, CLI commands, test suites).
+**Driven adapters** (right): called by the core (database, email, external APIs).
 **Ports**: interfaces defined by the core, implemented by adapters.
 
 ## Core concepts
@@ -37,7 +37,7 @@ flowchart LR
 - **Dependency rule**: the core never imports from adapters. Adapters import from the core.
 - **Symmetry**: the pattern applies equally to input (driving) and output (driven) sides.
 
-## Decision considerations / trade-offs
+## Trade-offs
 | | Pro | Con |
 |---|---|---|
 | Testability | Core logic tested without infrastructure | More interfaces and classes to maintain |
@@ -52,7 +52,7 @@ flowchart LR
 - **Avoid when**: the team is very small and the system has minimal external integrations.
 - **Avoid when**: a simple layered architecture meets the same need with less overhead.
 
-## Practical examples
+## Examples
 - Payment service where `PaymentGateway` is a port, implemented by `StripeAdapter` and `PaypalAdapter`.
 - Notification service where `NotificationSender` is a port, switchable between email, SMS, or webhook adapters.
 - Test suite that drives the core via the input port without starting an HTTP server.

--- a/architecture-patterns/layered.md
+++ b/architecture-patterns/layered.md
@@ -7,7 +7,7 @@ The most common form has four layers: presentation, application, domain, and inf
 
 ## Topology
 
-Each layer has a single, well-defined responsibility. Dependencies flow strictly downward — upper layers may call lower layers, but never the reverse.
+Each layer has a single, well-defined responsibility. Dependencies flow strictly downward: upper layers may call lower layers, but never the reverse.
 
 ```mermaid
 flowchart TB
@@ -29,7 +29,7 @@ flowchart TB
 - **Infrastructure layer**: handles persistence, external services, messaging, and I/O.
 
 
-## Decision considerations / trade-offs
+## Trade-offs
 
 | | Pro | Con |
 |---|---|---|
@@ -44,7 +44,7 @@ flowchart TB
 - **Avoid when**: many cross-cutting concerns dominate the design.
 - **Avoid when**: teams need independent release cycles for different functional areas.
 
-## Practical examples
+## Examples
 - A REST API with controllers -> service classes -> repositories -> database.
 - A backend application where domain validation never imports from ORM or HTTP frameworks.
 - Starting architecture for a new product before scaling needs are clear.

--- a/architecture-patterns/microkernel.md
+++ b/architecture-patterns/microkernel.md
@@ -32,7 +32,7 @@ The core calls out to plug-ins at defined extension points. Plug-ins implement t
 - **Extension point**: an interface defined by the core that marks where plug-in behavior can be injected. The stability of these interfaces determines how often plug-ins need to change.
 - **Registry**: the mechanism that maps extension points to concrete plug-in implementations at runtime (configuration file, DI container, service locator).
 
-## Decision considerations / trade-offs
+## Trade-offs
 
 | | Pro | Con |
 |---|---|---|
@@ -42,14 +42,14 @@ The core calls out to plug-ins at defined extension points. Plug-ins implement t
 | Changeability | Variable or customer-specific logic lives outside the core | Deciding what belongs in the core vs. a plug-in requires discipline |
 
 ## When to use / when not to use
-- **Use when**: the system has stable core rules but many varying extensions — product variants, customer-specific logic, jurisdiction-specific regulations.
+- **Use when**: the system has stable core rules but many varying extensions: product variants, customer-specific logic, jurisdiction-specific regulations.
 - **Use when**: different feature sets evolve at different speeds and must not block each other.
 - **Use when**: external teams or third parties need to contribute capabilities without access to the core.
 - **Avoid when**: the feature set is fixed and unlikely to grow. The extension-point machinery adds overhead for no benefit.
 - **Avoid when**: plug-ins need to coordinate heavily with each other; strong inter-plug-in coupling defeats the design.
 - **Avoid when**: dynamic plug-in loading conflicts with strict latency or startup-time requirements.
 
-## Practical examples
+## Examples
 - **Insurance platform**: core handles the universal claims process; plug-ins implement product-specific or country-specific calculation rules.
 - **Tax engine**: core drives the calculation workflow; plug-ins provide jurisdiction-specific rules.
 - **IDE** (VS Code, IntelliJ): core manages the editor model; language support, debuggers, and linters are plug-ins.

--- a/architecture-patterns/microservices.md
+++ b/architecture-patterns/microservices.md
@@ -3,7 +3,7 @@
 ## Overview
 Microservices is an architectural style where a system is composed of small, independently deployable services. Each service is owned by a single team, has its own data store, and communicates with other services over the network.
 
-The goal is independent deployability, scalability, and team autonomy — not small code size.
+The goal is independent deployability, scalability, and team autonomy, not small code size.
 
 ## Topology
 
@@ -36,12 +36,12 @@ flowchart TB
 ## Core concepts
 - **Single responsibility**: each service covers exactly one business domain and owns the data within it.
 - **Independent deployment**: a service can be deployed without touching anything else.
-- **Data isolation**: each service has its own database —> no shared tables, no direct cross-service queries.
+- **Data isolation**: each service has its own database: no shared tables, no direct cross-service queries.
 - **Network communication**: services talk to each other via HTTP/REST, gRPC, or a message broker.
 - **API Gateway**: the single entry point for clients; handles routing, auth, and rate limiting.
 - **Bounded context**: service boundaries follow business domains, not technical layers.
 
-## Decision considerations / trade-offs
+## Trade-offs
 | | Pro | Con |
 |---|---|---|
 | Deployment | Each service ships on its own schedule | Every service needs its own CI/CD pipeline |
@@ -56,10 +56,10 @@ flowchart TB
 - **Use when**: different parts of the system have significantly different scaling requirements.
 - **Use when**: the team can handle the operational complexity (CI/CD, observability, containers).
 - **Avoid when**: the team is small and the overhead isn't worth it.
-- **Avoid when**: bounded contexts are not yet well understood — wrong boundaries are expensive to fix.
+- **Avoid when**: bounded contexts are not yet well understood. Wrong boundaries are expensive to fix.
 - **Avoid when**: you are building an early-stage product with rapidly changing requirements.
 
-## Practical examples
+## Examples
 - An e-commerce platform where `Orders`, `Billing`, `Inventory`, and `Shipping` are separate services with independent deployments.
 - `Orders` publishes an `OrderPlaced` event; `Billing` and `Notifications` consume it asynchronously.
 - `Inventory` is scaled to 10 instances during peak season; `Notifications` runs at 2 instances.

--- a/architecture-patterns/modular-monolith.md
+++ b/architecture-patterns/modular-monolith.md
@@ -33,19 +33,19 @@ flowchart TB
   end
 ```
 
-Each module owns its code and data. Cross-module access goes through the public interface only — never via direct schema access or internal imports.
+Each module owns its code and data. Cross-module access goes through the public interface only, never via direct schema access or internal imports.
 
 ## Core concepts
 - **Module boundary**: a hard separation between modules, enforced by code structure or tooling (e.g., package visibility, linting rules, ArchUnit).
 - **Public interface**: the only entry point another module can call. Typically a service class or a defined API contract.
 - **Private internals**: all implementation details, database schemas, and internal models are hidden from other modules.
 - **Single deployment**: all modules compile and deploy together. No network calls between modules.
-- **Shared infrastructure**: modules share the same process, runtime, and often the same database — but not the same schema or tables.
+- **Shared infrastructure**: modules share the same process, runtime, and often the same database, but not the same schema or tables.
 
-## Decision considerations / trade-offs
+## Trade-offs
 | | Pro | Con |
 |---|---|---|
-| Deployment | Simple —> one artifact, no service mesh | Single point of failure |
+| Deployment | Simple: one artifact, no service mesh | Single point of failure |
 | Development | Refactoring across modules is easy in one codebase | Discipline needed to enforce boundaries |
 | Testing | Integration tests without network overhead | No isolation between module failures at runtime |
 | Scalability | Can scale the whole unit vertically | Cannot scale individual modules independently |

--- a/cloud-architecture/compute.md
+++ b/cloud-architecture/compute.md
@@ -23,10 +23,10 @@ Full control over the operating system and runtime; the platform manages only th
 Package an application with its dependencies into a portable, reproducible unit. An orchestrator (e.g. Kubernetes) schedules containers across hosts, restarts failed ones, and scales replicas. Containers give consistent environments from local development to production, at the cost of operating the orchestration layer.
 
 ### Serverless
-The platform runs business logic in response to events and manages everything else — provisioning, scaling, and capacity. Billing follows actual use and can scale to zero. The trade-offs are cold starts on infrequently used functions, execution limits, and tighter coupling to platform-specific triggers.
+The platform runs business logic in response to events and manages everything else: provisioning, scaling, and capacity. Billing follows actual use and can scale to zero. The trade-offs are cold starts on infrequently used functions, execution limits, and tighter coupling to platform-specific triggers.
 
 ### Managed services
-The platform operates a capability — a database, queue, or cache — and the team only configures it. This removes most operational work in exchange for less control and a dependency on the provider's implementation.
+The platform operates a capability (a database, queue, or cache) and the team only configures it. This removes most operational work in exchange for less control and a dependency on the provider's implementation.
 
 ---
 

--- a/cloud-architecture/cost.md
+++ b/cloud-architecture/cost.md
@@ -1,13 +1,13 @@
 # Cost
 
 ## Overview
-In the cloud, cost is an architectural property. Pay-per-use pricing means design decisions — compute model, redundancy level, data placement, traffic flow — translate directly into a recurring bill. Cost is therefore something to design for, not a number to discover at the end of the month.
+In the cloud, cost is an architectural property. Pay-per-use pricing means design decisions, such as compute model, redundancy level, data placement, and traffic flow, translate directly into a recurring bill. Cost is therefore something to design for, not a number to discover at the end of the month.
 
 ---
 
 ## The cloud cost model
 
-- **Pay-per-use**: you are billed for what you consume — compute time, storage, requests, and data transfer — rather than for owned hardware.
+- **Pay-per-use**: you are billed for what you consume (compute time, storage, requests, and data transfer) rather than for owned hardware.
 - **Scale to zero**: some models (serverless) cost nothing when idle; others (instances) bill continuously whether used or not.
 - **Committed vs on-demand**: reserved or committed capacity is cheaper per unit but trades flexibility for a longer commitment.
 - **Egress**: data leaving a region or the provider's network is billed, often more than people expect. Inbound transfer is usually free.

--- a/cloud-architecture/data.md
+++ b/cloud-architecture/data.md
@@ -19,13 +19,13 @@ How state is structured, evolved, and indexed is covered in [Data Architecture](
 
 ## Data residency and sovereignty
 
-Where data physically lives is a legal and architectural constraint, not only a latency concern. Regulations may require that certain data stay within a jurisdiction. Residency requirements influence region selection, replication topology, and which managed services are usable — decide them before choosing products.
+Where data physically lives is a legal and architectural constraint, not only a latency concern. Regulations may require that certain data stay within a jurisdiction. Residency requirements influence region selection, replication topology, and which managed services are usable. Decide them before choosing products.
 
 ---
 
 ## Replication and consistency
 
-Cloud data services replicate data for durability and availability. Replication introduces more than one copy of the same data, which raises the question of what a read guarantees — see [Consistency Models](../system-design/consistency-models.md). Backups and recovery targets are part of [Reliability](reliability.md).
+Cloud data services replicate data for durability and availability. Replication introduces more than one copy of the same data, which raises the question of what a read guarantees (see [Consistency Models](../system-design/consistency-models.md)). Backups and recovery targets are part of [Reliability](reliability.md).
 
 ---
 

--- a/cloud-architecture/index.md
+++ b/cloud-architecture/index.md
@@ -1,7 +1,7 @@
 # Cloud Architecture
 
 ## Overview
-Cloud architecture is the discipline of designing systems that run on shared, remotely operated infrastructure — rather than servers you own and manage yourself.
+Cloud architecture is the discipline of designing systems that run on shared, remotely operated infrastructure, rather than servers you own and manage yourself.
 
 The shift to cloud is not primarily a technology decision. It is a decision about **who owns which operational concerns**: compute capacity, hardware failures, network redundancy, physical security. Cloud providers absorb those concerns. In return, architects must make intentional choices about how to use the capabilities the cloud exposes.
 
@@ -33,7 +33,7 @@ flowchart TD
 | **Reliability** | What is my tolerance for downtime and data loss? | Redundancy, failover, backups, recovery targets |
 | **Observability** | How do I know my system is healthy? | Logs, metrics, traces, alerts |
 
-Security cuts across all five pillars — it is not a separate concern added at the end, but a property of how each pillar is designed.
+Security cuts across all five pillars. It is not a separate concern added at the end, but a property of how each pillar is designed.
 
 ---
 
@@ -41,10 +41,10 @@ Security cuts across all five pillars — it is not a separate concern added at 
 
 | Topic | Concern |
 |---|---|
-| [Compute](compute.md) | The model that runs a workload — virtual machines, containers, serverless, managed services |
-| [Networking](networking.md) | The path traffic takes to a service — DNS, CDN, load balancers, API gateways, network boundaries |
-| [Data](data.md) | Where state lives and who can reach it — managed stores, object storage, caches, residency |
-| [Reliability](reliability.md) | Designing for failure — availability zones, regions, redundancy, recovery targets |
+| [Compute](compute.md) | The model that runs a workload: virtual machines, containers, serverless, managed services |
+| [Networking](networking.md) | The path traffic takes to a service: DNS, CDN, load balancers, API gateways, network boundaries |
+| [Data](data.md) | Where state lives and who can reach it: managed stores, object storage, caches, residency |
+| [Reliability](reliability.md) | Designing for failure: availability zones, regions, redundancy, recovery targets |
 | [Infrastructure as Code](infrastructure-as-code.md) | Provisioning infrastructure as versioned, repeatable definitions |
 | [Cost](cost.md) | How architectural choices translate into a recurring bill |
 

--- a/cloud-architecture/infrastructure-as-code.md
+++ b/cloud-architecture/infrastructure-as-code.md
@@ -1,7 +1,7 @@
 # Infrastructure as Code
 
 ## Overview
-Infrastructure as Code (IaC) defines infrastructure — networks, compute, databases, permissions — as versioned, machine-readable files rather than manual console actions. The same files provision every environment, so infrastructure becomes repeatable, reviewable, and auditable.
+Infrastructure as Code (IaC) defines infrastructure (networks, compute, databases, permissions) as versioned, machine-readable files rather than manual console actions. The same files provision every environment, so infrastructure becomes repeatable, reviewable, and auditable.
 
 ---
 
@@ -12,7 +12,7 @@ Infrastructure as Code (IaC) defines infrastructure — networks, compute, datab
 | **Declarative** | The desired end state; the tool computes the steps | Terraform, CloudFormation |
 | **Imperative** | The sequence of steps to reach the state | Scripts, provisioning SDKs |
 
-Declarative IaC is the common default: it converges the real infrastructure toward the described state and can detect **drift** — manual changes that diverge from the definition.
+Declarative IaC is the common default: it converges the real infrastructure toward the described state and can detect **drift**: manual changes that diverge from the definition.
 
 ---
 

--- a/cloud-architecture/reliability.md
+++ b/cloud-architecture/reliability.md
@@ -26,7 +26,7 @@ flowchart LR
 
 **Regions** are geographic locations. Multi-region deployment protects against large-scale outages and reduces latency for global users.
 
-The right level of redundancy depends on your **availability target** and **data sensitivity** — not on what is technically possible.
+The right level of redundancy depends on your **availability target** and **data sensitivity**, not on what is technically possible.
 
 ---
 

--- a/decision-making/index.md
+++ b/decision-making/index.md
@@ -10,7 +10,7 @@ Architecture decisions shape the system for years. Making them explicit reduces 
 - New service design: define problem, constraints, options, and a clear decision.
 - Build vs buy: compare strategic fit, total cost, and operational impact.
 
-## Decision considerations / trade-offs
+## Trade-offs
 - More governance reduces risk but can slow delivery.
 - Documenting decisions adds overhead but prevents repeated debates.
 - Centralized decisions improve alignment but reduce team autonomy.

--- a/design-patterns/behavioral/mediator.md
+++ b/design-patterns/behavioral/mediator.md
@@ -4,11 +4,11 @@ The Mediator pattern defines a central object that encapsulates how a set of oth
 
 ## How it works
 
-Each participating object holds a reference to the mediator instead of holding references to its peers. When something happens that other objects should know about, the object notifies the mediator. The mediator then decides which other objects to inform and what to do with the information. The participants are decoupled from each other — they only know the mediator.
+Each participating object holds a reference to the mediator instead of holding references to its peers. When something happens that other objects should know about, the object notifies the mediator. The mediator then decides which other objects to inform and what to do with the information. The participants are decoupled from each other; they only know the mediator.
 
 ## Example
 
-A booking form with three controls: a "collect at store" checkbox, an address field, and a submit button. The controls don't reference each other — they all notify the mediator, which holds the coordination logic.
+A booking form with three controls: a "collect at store" checkbox, an address field, and a submit button. The controls don't reference each other; they all notify the mediator, which holds the coordination logic.
 
 ```python
 from __future__ import annotations

--- a/design-patterns/behavioral/memento.md
+++ b/design-patterns/behavioral/memento.md
@@ -93,5 +93,5 @@ if snapshot:
 ## When not to use
 
 - The object's state is large or changes frequently. Storing full snapshots on every change is expensive in both memory and time.
-- The caretaker needs to inspect or manipulate the snapshot content. A memento should be opaque — if the caretaker needs to understand it, a different mechanism is more appropriate.
+- The caretaker needs to inspect or manipulate the snapshot content. A memento should be opaque. If the caretaker needs to understand it, a different mechanism is more appropriate.
 - Rollback is only needed in exceptional error cases, not as a regular feature. In that case simpler error handling or a transaction boundary is a better fit.

--- a/design-patterns/creational/abstract-factory.md
+++ b/design-patterns/creational/abstract-factory.md
@@ -4,7 +4,7 @@ The Abstract Factory pattern provides an interface for creating families of rela
 
 ## How it works
 
-An abstract factory interface declares creation methods for each product in the family. A concrete factory implements all of them for one specific variant. Client code receives a factory and only ever calls its creation methods — it never knows which concrete classes are being instantiated.
+An abstract factory interface declares creation methods for each product in the family. A concrete factory implements all of them for one specific variant. Client code receives a factory and only ever calls its creation methods; it never knows which concrete classes are being instantiated.
 
 ## Example
 

--- a/design-patterns/creational/factory-method.md
+++ b/design-patterns/creational/factory-method.md
@@ -8,7 +8,7 @@ A base class declares an abstract factory method that returns a product object. 
 
 ## Example
 
-A logistics platform needs to plan deliveries. The planning logic (route validation, cost estimation) is the same regardless of transport type — but which transport gets created differs per subclass.
+A logistics platform needs to plan deliveries. The planning logic (route validation, cost estimation) is the same regardless of transport type, but which transport gets created differs per subclass.
 
 ```python
 from abc import ABC, abstractmethod
@@ -61,7 +61,7 @@ logistics.plan_delivery("Rotterdam")
 # Ship sailing to Rotterdam
 ```
 
-The key insight: `plan_delivery` is written once in the base class and never changes. Adding a new transport type (e.g. `AirLogistics`) only requires a new subclass — no existing code is touched.
+The key insight: `plan_delivery` is written once in the base class and never changes. Adding a new transport type (e.g. `AirLogistics`) only requires a new subclass, and no existing code is touched.
 
 ## Simple Factory vs. Factory Method
 
@@ -76,7 +76,7 @@ def create_transport(mode: str) -> Transport:
     raise ValueError(f"Unknown mode: {mode}")
 ```
 
-This is simpler and more direct — but adding a new type requires changing this function. Factory Method is worth the indirection only when real extensibility is needed: when subclasses or external consumers should be able to add new types without touching existing code.
+This is simpler and more direct, but adding a new type requires changing this function. Factory Method is worth the indirection only when real extensibility is needed: when subclasses or external consumers should be able to add new types without touching existing code.
 
 ## When to use
 

--- a/design-patterns/index.md
+++ b/design-patterns/index.md
@@ -1,6 +1,6 @@
 # Design Patterns
 
-Design patterns are proven, reusable solutions to recurring software design problems. They are not code — they are templates for solving a class of problem in a given context.
+Design patterns are proven, reusable solutions to recurring software design problems. They are not code: they are templates for solving a class of problem in a given context.
 
 The canonical catalog comes from the Gang of Four (GoF) book *Design Patterns* (1994) and divides patterns into three categories based on their purpose:
 
@@ -62,13 +62,13 @@ Define how objects interact and distribute responsibility. Focus on algorithms a
 
 ---
 
-## Decision considerations / trade-offs
+## Trade-offs
 
 | | Pro | Con |
 |---|---|---|
 | Shared vocabulary | Patterns give teams a common language ("use a Strategy here") | Overuse leads to pattern-for-pattern's-sake code that obscures intent |
 | Reuse | Tested structure reduces bugs in recurring problems | Applying the wrong pattern creates unnecessary indirection |
-| Extensibility | Open/closed principle — extend without modifying existing code | Additional abstractions increase cognitive load for new team members |
+| Extensibility | Open/closed principle: extend without modifying existing code | Additional abstractions increase cognitive load for new team members |
 | Testability | Interfaces and injection points make units easier to test | Too many patterns can make it hard to trace execution flow |
 
 ---

--- a/foundations/glossary.md
+++ b/foundations/glossary.md
@@ -45,7 +45,7 @@ Fitness functions can be automated (e.g. run in CI) or manual (e.g. periodic arc
 ---
 
 **Contention**
-Contention occurs when multiple threads, processes, or services compete for the same shared resource at the same time — such as a CPU, a lock, or a database connection. The resource can only serve one at a time, so others have to wait. This waiting is a common cause of latency and poor performance under load.
+Contention occurs when multiple threads, processes, or services compete for the same shared resource at the same time, such as a CPU, a lock, or a database connection. The resource can only serve one at a time, so others have to wait. This waiting is a common cause of latency and poor performance under load.
 
 A typical example is lock contention: two threads both want to write to the same data structure. One acquires the lock and proceeds, the other blocks until the lock is released.
 ```python

--- a/foundations/modularity.md
+++ b/foundations/modularity.md
@@ -34,13 +34,13 @@ Coupling measures how much one module depends on another. Low coupling means mod
 
 | Type | Description | Risk |
 |---|---|---|
-| Content coupling | Module A directly accesses internals of module B | Highest — any internal change breaks A |
-| Common coupling | Modules share global mutable state | High — changes to shared state affect all |
-| External coupling | Modules depend on the same external format or protocol | Medium-high — protocol changes affect all |
-| Control coupling | Module A passes a flag that controls module B's behavior | Medium — B's logic is driven by A |
-| Stamp coupling | Modules share a complex data structure, only use parts of it | Medium — changes to the structure affect both |
-| Data coupling | Modules communicate via simple, minimal data (parameters) | Low — only the interface matters |
-| Message coupling | Modules communicate only via messages or events | Lowest — no shared knowledge |
+| Content coupling | Module A directly accesses internals of module B | Highest: any internal change breaks A |
+| Common coupling | Modules share global mutable state | High: changes to shared state affect all |
+| External coupling | Modules depend on the same external format or protocol | Medium-high: protocol changes affect all |
+| Control coupling | Module A passes a flag that controls module B's behavior | Medium: B's logic is driven by A |
+| Stamp coupling | Modules share a complex data structure, only use parts of it | Medium: changes to the structure affect both |
+| Data coupling | Modules communicate via simple, minimal data (parameters) | Low: only the interface matters |
+| Message coupling | Modules communicate only via messages or events | Lowest: no shared knowledge |
 
 
 ### Coupling dimensions
@@ -65,20 +65,20 @@ It was introduced by Meilir Page-Jones and provides a vocabulary for describing 
 
 | Type | Description | Example |
 |---|---|---|
-| **CoN** — Name | Both agree on the name of something | A method name used in caller and callee |
-| **CoT** — Type | Both agree on the type of something | Passing a `User` object between modules |
-| **CoM** — Meaning | Both agree on the meaning of a value | `status = 1` means "active" in both |
-| **CoP** — Position | Both agree on the order of values | `createUser(name, email)` — order matters |
-| **CoA** — Algorithm | Both must use the same algorithm | Hashing a password the same way on both sides |
+| **CoN**: Name | Both agree on the name of something | A method name used in caller and callee |
+| **CoT**: Type | Both agree on the type of something | Passing a `User` object between modules |
+| **CoM**: Meaning | Both agree on the meaning of a value | `status = 1` means "active" in both |
+| **CoP**: Position | Both agree on the order of values | `createUser(name, email)`, order matters |
+| **CoA**: Algorithm | Both must use the same algorithm | Hashing a password the same way on both sides |
 
 ### Dynamic connascence (only detectable at runtime)
 
 | Type | Description | Example |
 |---|---|---|
-| **CoE** — Execution | Both must execute in a specific order | Must call `init()` before `run()` |
-| **CoTi** — Timing | Both must execute at the same time | Race condition between two threads |
-| **CoV** — Values | Related values must change together | `startDate` and `endDate` must stay consistent |
-| **CoI** — Identity | Both must reference the exact same instance | Two components sharing a mutable object |
+| **CoE**: Execution | Both must execute in a specific order | Must call `init()` before `run()` |
+| **CoTi**: Timing | Both must execute at the same time | Race condition between two threads |
+| **CoV**: Values | Related values must change together | `startDate` and `endDate` must stay consistent |
+| **CoI**: Identity | Both must reference the exact same instance | Two components sharing a mutable object |
 
 ### Connascence strength
 
@@ -123,7 +123,7 @@ flowchart TB
 ```
 
 - High cohesion naturally reduces coupling, a focused module has fewer reasons to touch other modules.
-- Low coupling reduces connascence — fewer dependencies mean fewer things that must change together.
+- Low coupling reduces connascence: fewer dependencies mean fewer things that must change together.
 - Connascence gives you a vocabulary to *identify* and *prioritize* what to refactor.
 
 ---
@@ -131,7 +131,7 @@ flowchart TB
 ## Practical guidelines
 
 - Name modules after what they *do*, not what they *contain* (`OrderPlacer`, not `OrderUtils`).
-- A module that is hard to test in isolation has high coupling — treat this as a design signal.
+- A module that is hard to test in isolation has high coupling; treat this as a design signal.
 - If you cannot describe a module's responsibility in one sentence, it likely has low cohesion.
 - Replace positional arguments (CoP) with typed objects or named parameters.
 - Replace magic values (CoM) with constants or enums with shared names (CoN).

--- a/quality-attributes/compatibility/co-existence.md
+++ b/quality-attributes/compatibility/co-existence.md
@@ -26,7 +26,7 @@ Co-existence is achieved through isolation: the degree to which a system's resou
 
 ### Co-existence vs. interoperability
 
-Co-existence concerns whether systems can run alongside each other without interfering. Interoperability concerns whether they can exchange information correctly. A system can co-exist without interoperating — and vice versa.
+Co-existence concerns whether systems can run alongside each other without interfering. Interoperability concerns whether they can exchange information correctly. A system can co-exist without interoperating, and vice versa.
 
 ---
 

--- a/quality-attributes/compatibility/interoperability.md
+++ b/quality-attributes/compatibility/interoperability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Interoperability is the degree to which two or more systems can exchange information and use the information that has been exchanged. It requires agreement on data formats, protocols, semantics, and error handling — not just technical connectivity.
+Interoperability is the degree to which two or more systems can exchange information and use the information that has been exchanged. It requires agreement on data formats, protocols, semantics, and error handling, not just technical connectivity.
 
 Systems can be technically connected (messages are transmitted) but still lack interoperability if the receiving system cannot correctly interpret or act on the exchanged data.
 
@@ -23,13 +23,13 @@ Most integration problems occur at the semantic and behavioural levels, not the 
 
 ### Interface contracts
 
-Interoperability depends on explicit contracts that define the format, semantics, and versioning of exchanged data. Implicit contracts — undocumented but relied-upon behaviours — are a frequent source of integration failures during evolution.
+Interoperability depends on explicit contracts that define the format, semantics, and versioning of exchanged data. Implicit contracts, undocumented but relied-upon behaviours, are a frequent source of integration failures during evolution.
 
 Contract formats: OpenAPI for REST, Protobuf/gRPC for binary RPC, Avro/JSON Schema for event streams, AsyncAPI for message-based systems.
 
 ### Versioning and evolution
 
-Interoperability needs to be maintained as systems evolve independently. Breaking changes — removed fields, changed types, reordered enum values, altered error codes — break consumers without notice unless versioning is explicit and backward compatibility is a design constraint.
+Interoperability needs to be maintained as systems evolve independently. Breaking changes (removed fields, changed types, reordered enum values, altered error codes) break consumers without notice unless versioning is explicit and backward compatibility is a design constraint.
 
 ---
 
@@ -60,5 +60,5 @@ Interoperability needs to be maintained as systems evolve independently. Breakin
 ## Common pitfalls
 
 - **Undocumented implicit contracts**: consumers build on observed behaviour that was never specified. The producer changes it; consumers break. Interfaces with external consumers generally benefit from an explicit contract.
-- **Semantic mismatch**: field names match but meanings diverge — a `status` field that means different things to producer and consumer. Shared vocabulary and canonical data models prevent this.
+- **Semantic mismatch**: field names match but meanings diverge, such as a `status` field that means different things to producer and consumer. Shared vocabulary and canonical data models prevent this.
 - **No backward compatibility policy**: teams evolve their APIs without defining what constitutes a breaking change. Consumers discover breakage at runtime.

--- a/quality-attributes/functional-suitability/functional-appropriateness.md
+++ b/quality-attributes/functional-suitability/functional-appropriateness.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Functional appropriateness is the degree to which the functions facilitate the accomplishment of specified tasks and objectives. A system is appropriate when its functions directly support user goals — and does not expose unnecessary complexity, irrelevant options, or functions that require users to work around them.
+Functional appropriateness is the degree to which the functions facilitate the accomplishment of specified tasks and objectives. A system is appropriate when its functions directly support user goals and does not expose unnecessary complexity, irrelevant options, or functions that require users to work around them.
 
 Appropriateness is a quality of fit: a technically complete and correct system can still be inappropriate if its functions make users' tasks harder, not easier.
 
@@ -20,7 +20,7 @@ Functions that are more general, more configurable, or more capable than the tas
 
 ### User task alignment
 
-Appropriateness is evaluated relative to the user's mental model of their task. Functions that force users to translate between their mental model and the system's model reduce appropriateness — even if the underlying logic is correct.
+Appropriateness is evaluated relative to the user's mental model of their task. Functions that force users to translate between their mental model and the system's model reduce appropriateness, even if the underlying logic is correct.
 
 ---
 

--- a/quality-attributes/functional-suitability/functional-completeness.md
+++ b/quality-attributes/functional-suitability/functional-completeness.md
@@ -12,11 +12,11 @@ Completeness failures are often invisible during development and surface at acce
 
 ### Specified vs. implied needs
 
-Completeness applies to both explicitly documented requirements and to needs that are reasonably implied by context. A payment system that processes successful transactions but provides no refund mechanism is functionally incomplete — even if refunds were never explicitly written into a requirement.
+Completeness applies to both explicitly documented requirements and to needs that are reasonably implied by context. A payment system that processes successful transactions but provides no refund mechanism is functionally incomplete, even if refunds were never explicitly written into a requirement.
 
 ### Completeness vs. scope creep
 
-Completeness does not mean implementing everything. It means implementing everything within the agreed scope. Undocumented assumptions on either side — features the team assumed were out of scope that users assumed were included — are the primary source of completeness gaps.
+Completeness does not mean implementing everything. It means implementing everything within the agreed scope. Undocumented assumptions on either side (features the team assumed were out of scope that users assumed were included) are the primary source of completeness gaps.
 
 ### Acceptance criteria as completeness contracts
 

--- a/quality-attributes/functional-suitability/functional-correctness.md
+++ b/quality-attributes/functional-suitability/functional-correctness.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Functional correctness is the degree to which a system produces the right results with the required degree of precision. A system is functionally correct when it faithfully implements the intended domain logic — not just when it avoids crashes or returns a response.
+Functional correctness is the degree to which a system produces the right results with the required degree of precision. A system is functionally correct when it faithfully implements the intended domain logic, not just when it avoids crashes or returns a response.
 
 Correctness failures are often silent: the system runs, but the output is wrong. They can be more costly than availability failures because incorrect data propagates and may require manual correction.
 
@@ -16,7 +16,7 @@ These are distinct properties. Functional correctness asks: does the system impl
 
 ### Domain logic as the source of truth
 
-Correctness is determined by the domain model. Business rules — calculation formulas, state transition constraints, validation conditions — should be represented explicitly in code and should match the agreed specification. Ambiguous specifications tend to produce incorrect implementations regardless of code quality.
+Correctness is determined by the domain model. Business rules (calculation formulas, state transition constraints, validation conditions) should be represented explicitly in code and should match the agreed specification. Ambiguous specifications tend to produce incorrect implementations regardless of code quality.
 
 ### Precision
 
@@ -37,7 +37,7 @@ Correctness includes precision: a tax calculation rounded to the wrong number of
 
 ## When to prioritize
 
-- Financial calculations, tax logic, legal computations — any domain where incorrect output has direct monetary or legal consequences.
+- Financial calculations, tax logic, legal computations: any domain where incorrect output has direct monetary or legal consequences.
 - Systems where downstream consumers depend on the correctness of the output.
 - Regulated domains with audit requirements.
 
@@ -51,4 +51,4 @@ Correctness includes precision: a tax calculation rounded to the wrong number of
 
 - **Business logic distributed across layers**: rules split between the domain layer, the API handler, and the database trigger tend to be inconsistent and untestable as a unit. Centralising domain logic reduces this risk.
 - **Specification ambiguity accepted as normal**: deferring ambiguity to implementation tends to produce systems that are internally consistent but externally incorrect. Resolving ambiguity before implementation reduces this risk.
-- **Testing only the happy path**: correctness tests should cover boundary conditions, negative cases, and precision edge cases — not just the common scenario.
+- **Testing only the happy path**: correctness tests should cover boundary conditions, negative cases, and precision edge cases, not just the common scenario.

--- a/quality-attributes/functional-suitability/index.md
+++ b/quality-attributes/functional-suitability/index.md
@@ -1,6 +1,6 @@
 # Functional Suitability
 
-Functional suitability describes the degree to which a system provides functions that meet stated and implied needs under specified conditions. It is the only quality characteristic that concerns *what* a system does rather than *how well* it does it — correctness at the functional level is a baseline the other characteristics build on.
+Functional suitability describes the degree to which a system provides functions that meet stated and implied needs under specified conditions. It is the only quality characteristic that concerns *what* a system does rather than *how well* it does it. Correctness at the functional level is a baseline the other characteristics build on.
 
 ## Sub-characteristics
 
@@ -8,4 +8,4 @@ Functional suitability describes the degree to which a system provides functions
 |---|---|
 | [Functional Completeness](functional-completeness.md) | The set of functions covers all specified tasks and user objectives |
 | [Functional Correctness](functional-correctness.md) | The system produces correct results with the required degree of precision |
-| [Functional Appropriateness](functional-appropriateness.md) | Functions facilitate the accomplishment of specified tasks — no more, no less |
+| [Functional Appropriateness](functional-appropriateness.md) | Functions facilitate the accomplishment of specified tasks: no more, no less |

--- a/quality-attributes/index.md
+++ b/quality-attributes/index.md
@@ -1,6 +1,6 @@
 # Quality Attributes
 
-Quality attributes — also called non-functional requirements — describe how a system behaves, not what it does. They are often primary drivers of architectural decisions: the same feature set can be implemented with fundamentally different architectures depending on the quality targets.
+Quality attributes, also called non-functional requirements, describe how a system behaves, not what it does. They are often primary drivers of architectural decisions: the same feature set can be implemented with fundamentally different architectures depending on the quality targets.
 
 ---
 
@@ -19,7 +19,7 @@ Without a measurable target, there is no basis for architectural decisions and n
 
 ## Quality attributes covered in this guide
 
-The attributes below are treated as independent architectural concerns. They align with ISO 25010 but are not structured to mirror its hierarchy — some ISO sub-characteristics (availability, scalability) are elevated to standalone entries because they drive distinct architectural decisions.
+The attributes below are treated as independent architectural concerns. They align with ISO 25010 but are not structured to mirror its hierarchy. Some ISO sub-characteristics (availability, scalability) are elevated to standalone entries because they drive distinct architectural decisions.
 
 | ISO 25010 Characteristic | Sub-characteristics |
 |---|---|
@@ -39,16 +39,16 @@ The attributes below are treated as independent architectural concerns. They ali
 Quality attributes are not independent. Architectural decisions that improve one often affect others.
 
 **Performance vs. Scalability**
-A system optimized for single-instance performance (e.g., heavy in-process caching, local state) may not scale horizontally. Scaling adds synchronization points — distributed locks, cache invalidation, coordination overhead — which increase latency and reduce throughput under certain patterns.
+A system optimized for single-instance performance (e.g., heavy in-process caching, local state) may not scale horizontally. Scaling adds synchronization points (distributed locks, cache invalidation, coordination overhead) which increase latency and reduce throughput under certain patterns.
 
 **Scalability vs. Availability**
 Statelessness is a prerequisite for horizontal scaling and simultaneously simplifies availability: stateless instances can be replaced or multiplied without session continuity concerns. Both attributes benefit from the same architectural decision.
 
 **Availability vs. Reliability**
-These are orthogonal. A system can have high availability (always reachable) but low reliability (returns wrong results). Redundancy increases availability by reducing downtime; it does not prevent a faulty component from being replicated. Reliability requires correctness guarantees — not just uptime.
+These are orthogonal. A system can have high availability (always reachable) but low reliability (returns wrong results). Redundancy increases availability by reducing downtime; it does not prevent a faulty component from being replicated. Reliability requires correctness guarantees, not just uptime.
 
 **Security vs. Usability**
-Security controls add friction. Authentication steps, session timeouts, and access restrictions reduce convenience. The appropriate balance is context-dependent — a banking application and a public content site have different thresholds.
+Security controls add friction. Authentication steps, session timeouts, and access restrictions reduce convenience. The appropriate balance is context-dependent: a banking application and a public content site have different thresholds.
 
 **Maintainability vs. Performance**
 Abstractions, layering, and modularity that improve maintainability can introduce overhead. Highly optimized code is often tightly coupled to its execution context and difficult to change. Performance optimizations should be introduced after measurable need is established, not speculatively.
@@ -62,4 +62,4 @@ Abstracting over provider-specific features to preserve portability sometimes me
 
 Quality attributes are sometimes treated as things to maximize after the system is built; they are better understood as constraints to be established before architectural decisions are made.
 
-If the target is unknown, any architecture is defensible — and none can be evaluated. Defining targets early, making them measurable, and using them to drive trade-off decisions explicitly supports more grounded architectural choices.
+If the target is unknown, any architecture is defensible, and none can be evaluated. Defining targets early, making them measurable, and using them to drive trade-off decisions explicitly supports more grounded architectural choices.

--- a/quality-attributes/maintainability/analysability.md
+++ b/quality-attributes/maintainability/analysability.md
@@ -29,7 +29,7 @@ Before making a change, a developer must be able to assess what the change will 
 - Dependency graphs that can be navigated without deep code reading
 - Test coverage that provides confidence about what breaks when a change is made
 
-Systems with hidden dependencies, implicit coupling, or tangled module graphs make impact analysis difficult and expensive — which can lead to regressions and conservative changes that defer technical debt cleanup.
+Systems with hidden dependencies, implicit coupling, or tangled module graphs make impact analysis difficult and expensive, which can lead to regressions and conservative changes that defer technical debt cleanup.
 
 ### Static analysis
 

--- a/quality-attributes/maintainability/index.md
+++ b/quality-attributes/maintainability/index.md
@@ -1,6 +1,6 @@
 # Maintainability
 
-Maintainability describes the degree to which a system can be modified by the intended maintainers. It is the quality characteristic most directly experienced by the engineering team during ongoing development — and one that can degrade under sustained delivery pressure.
+Maintainability describes the degree to which a system can be modified by the intended maintainers. It is the quality characteristic most directly experienced by the engineering team during ongoing development, and one that can degrade under sustained delivery pressure.
 
 ## Sub-characteristics
 

--- a/quality-attributes/maintainability/modifiability.md
+++ b/quality-attributes/maintainability/modifiability.md
@@ -25,7 +25,7 @@ A system is modifiable to the extent that it can be extended without being modif
 
 ### Dependency direction
 
-Dependencies that point in the wrong direction make the system hard to modify. In a layered architecture, domain logic that depends on infrastructure details (database schemas, HTTP frameworks) is coupled to those details — a change in the infrastructure requires changes in the domain. Inverting these dependencies (the domain defines interfaces; infrastructure implements them) isolates change.
+Dependencies that point in the wrong direction make the system hard to modify. In a layered architecture, domain logic that depends on infrastructure details (database schemas, HTTP frameworks) is coupled to those details: a change in the infrastructure requires changes in the domain. Inverting these dependencies (the domain defines interfaces; infrastructure implements them) isolates change.
 
 ---
 

--- a/quality-attributes/maintainability/modularity.md
+++ b/quality-attributes/maintainability/modularity.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Modularity is the degree to which a system is composed of discrete components such that a change in one component has minimal impact on other components. A modular system can be understood, changed, tested, and deployed in parts — which tends to reduce the cost and risk of individual changes.
+Modularity is the degree to which a system is composed of discrete components such that a change in one component has minimal impact on other components. A modular system can be understood, changed, tested, and deployed in parts, which tends to reduce the cost and risk of individual changes.
 
 Modularity in the ISO 25010 maintainability sense is directly addressed by the foundational concepts in this guide: see [Modularity](../../foundations/modularity.md) for cohesion, coupling, and connascence.
 
@@ -26,7 +26,7 @@ See [Modularity](../../foundations/modularity.md) for the full taxonomy of cohes
 
 ### Package and service boundaries
 
-Modularity applies at multiple levels: within a service (packages, classes), between services (APIs, events), and between deployment units (shared libraries, shared databases). The same principles apply at each level — but violations at higher levels (e.g., shared databases between services) are more costly to fix.
+Modularity applies at multiple levels: within a service (packages, classes), between services (APIs, events), and between deployment units (shared libraries, shared databases). The same principles apply at each level, but violations at higher levels (e.g., shared databases between services) are more costly to fix.
 
 ---
 

--- a/quality-attributes/maintainability/reusability.md
+++ b/quality-attributes/maintainability/reusability.md
@@ -14,15 +14,15 @@ Reusability reduces duplication and the associated cost of maintaining the same 
 
 Not all duplication is a problem. The cost of duplication (maintaining the same logic twice) should be weighed against the cost of the abstraction that would eliminate it. Three instances of similar logic are a signal to consider abstraction. A single instance is generally not sufficient justification to abstract.
 
-A poorly fitting abstraction — a reusable component that does not quite fit any of its use cases — can be more costly than the duplication it was meant to remove.
+A poorly fitting abstraction (a reusable component that does not quite fit any of its use cases) can be more costly than the duplication it was meant to remove.
 
 ### What makes a component reusable
 
 A reusable component:
 - Has a well-defined, stable interface
-- Depends only on what it needs — no unnecessary dependencies that callers must also acquire
-- Has a focused responsibility — a component that solves a general problem is often more reusable than one that solves a specific problem
-- Is documented — callers can understand its contract without reading its implementation
+- Depends only on what it needs: no unnecessary dependencies that callers must also acquire
+- Has a focused responsibility: a component that solves a general problem is often more reusable than one that solves a specific problem
+- Is documented: callers can understand its contract without reading its implementation
 
 ### Library design vs. application design
 

--- a/quality-attributes/maintainability/testability.md
+++ b/quality-attributes/maintainability/testability.md
@@ -4,7 +4,7 @@
 
 Testability is the degree to which test criteria can be established for a system or component, and tests can be performed to determine whether those criteria have been met. A testable system makes it possible to verify its behaviour in isolation, under controlled conditions, with fast and reliable feedback.
 
-Testability is a property of the design, not of the test suite. A component that is difficult to test in isolation often reflects a design concern — hidden dependencies, unclear responsibilities, or tightly coupled infrastructure.
+Testability is a property of the design, not of the test suite. A component that is difficult to test in isolation often reflects a design concern: hidden dependencies, unclear responsibilities, or tightly coupled infrastructure.
 
 ---
 
@@ -25,7 +25,7 @@ If a component is hard to test, the design is worth reconsidering. Common testab
 
 A test seam is a point in the design where the behaviour of the system can be changed for testing without modifying the code under test. Dependency injection is the primary mechanism: the component declares its dependencies as interfaces; tests inject test doubles.
 
-Without seams, tests must exercise the real implementation of every dependency — making tests slow, fragile, and coupled to external systems.
+Without seams, tests must exercise the real implementation of every dependency, making tests slow, fragile, and coupled to external systems.
 
 ### Test pyramid
 

--- a/quality-attributes/performance-efficiency/capacity.md
+++ b/quality-attributes/performance-efficiency/capacity.md
@@ -4,7 +4,7 @@
 
 Scalability describes whether a system's performance characteristics remain stable as load increases. It is not the same as performance: a system can be fast at low load but fail to maintain that performance as users or data volume grows.
 
-A scalable system can handle more work by adding resources — without requiring fundamental redesign.
+A scalable system can handle more work by adding resources, without requiring fundamental redesign.
 
 ---
 
@@ -16,10 +16,10 @@ A scalable system can handle more work by adding resources — without requiring
 |---|---|---|
 | Mechanism | Larger machines (more CPU, RAM) | More machines of the same size |
 | Limit | Physical ceiling of available hardware | Theoretically unbounded |
-| Complexity | Simple — no application changes needed | Requires stateless design and load distribution |
+| Complexity | Simple: no application changes needed | Requires stateless design and load distribution |
 | Cost | Expensive at the high end | More predictable unit economics |
 
-Vertical scaling is a valid short-term lever, but it has a ceiling. Horizontal scaling is a common approach for systems with growing load — and it requires the application to be designed for it from the start.
+Vertical scaling is a valid short-term lever, but it has a ceiling. Horizontal scaling is a common approach for systems with growing load, and it requires the application to be designed for it from the start.
 
 ### Statelessness
 
@@ -37,10 +37,10 @@ Elasticity is distinct from scalability. A system is scalable if it *can* handle
 
 When a system fails to scale, the bottleneck is typically one of the following, in order of how often they are encountered:
 
-1. **Compute** — CPU or memory saturation on a single instance. Solved by horizontal scaling.
-2. **Shared mutable state** — a distributed lock, a shared counter, or a serialized queue. Solved by partitioning or redesigning the data model.
-3. **Synchronous call chains** — a request must wait for N sequential downstream calls. Solved by async patterns or parallelism.
-4. **Database** — connection limits, single-writer bottleneck, or query performance at scale. A bottleneck that is often encountered late and can be operationally costly to address.
+1. **Compute**: CPU or memory saturation on a single instance. Solved by horizontal scaling.
+2. **Shared mutable state**: a distributed lock, a shared counter, or a serialized queue. Solved by partitioning or redesigning the data model.
+3. **Synchronous call chains**: a request must wait for N sequential downstream calls. Solved by async patterns or parallelism.
+4. **Database**: connection limits, single-writer bottleneck, or query performance at scale. A bottleneck that is often encountered late and can be operationally costly to address.
 
 Identifying the bottleneck before choosing a scaling strategy prevents applying the wrong lever.
 

--- a/quality-attributes/performance-efficiency/index.md
+++ b/quality-attributes/performance-efficiency/index.md
@@ -8,4 +8,4 @@ Performance efficiency describes the relationship between the performance of a s
 |---|---|
 | [Time Behaviour](time-behaviour.md) | Response and processing times and throughput rates when performing its functions |
 | [Resource Utilisation](resource-utilisation.md) | Amounts and types of resources used when performing functions |
-| [Capacity](capacity.md) | Maximum limits of a system parameter that meet requirements — and whether performance holds as load grows |
+| [Capacity](capacity.md) | Maximum limits of a system parameter that meet requirements, and whether performance holds as load grows |

--- a/quality-attributes/performance-efficiency/time-behaviour.md
+++ b/quality-attributes/performance-efficiency/time-behaviour.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Performance describes how fast a system responds to requests (latency) and how much work it can process concurrently (throughput). It is measurable and load-dependent — a system may perform well under low load and degrade significantly under realistic conditions.
+Performance describes how fast a system responds to requests (latency) and how much work it can process concurrently (throughput). It is measurable and load-dependent: a system may perform well under low load and degrade significantly under realistic conditions.
 
 Performance becomes an architectural driver when a naive implementation cannot meet the defined targets under the expected load profile. Optimizing before a baseline exists can consume design budget without clear benefit and often introduces accidental complexity.
 
@@ -21,20 +21,20 @@ Batching is the canonical example of the tension: grouping multiple operations i
 
 ### Percentiles, not averages
 
-Average latency hides the distribution. A p99 of 2s means 1% of users wait at least 2 seconds — which is often where SLA violations occur and where user experience degrades most noticeably.
+Average latency hides the distribution. A p99 of 2s means 1% of users wait at least 2 seconds, which is often where SLA violations occur and where user experience degrades most noticeably.
 
 | Metric | What it tells you |
 |---|---|
-| p50 | Median experience — typical user |
-| p95 | Near-tail — most users including slower cases |
-| p99 | Tail — outliers that often define perceived reliability |
-| p999 | Extreme tail — relevant for high-volume systems |
+| p50 | Median experience: typical user |
+| p95 | Near-tail: most users including slower cases |
+| p99 | Tail: outliers that often define perceived reliability |
+| p999 | Extreme tail: relevant for high-volume systems |
 
-Defining performance targets using percentiles tied to a load profile — for example, "p99 < 200ms at 1,000 concurrent users" — provides a concrete, testable basis for architectural decisions.
+Defining performance targets using percentiles tied to a load profile (for example, "p99 < 200ms at 1,000 concurrent users") provides a concrete, testable basis for architectural decisions.
 
 ### Performance budget
 
-A performance budget translates the system-level target into per-component allocations. If end-to-end p99 is 300ms and there are three sequential hops, each hop must be budgeted explicitly — leaving room for network overhead, serialization, and queueing.
+A performance budget translates the system-level target into per-component allocations. If end-to-end p99 is 300ms and there are three sequential hops, each hop must be budgeted explicitly, leaving room for network overhead, serialization, and queueing.
 
 ---
 

--- a/quality-attributes/portability/adaptability.md
+++ b/quality-attributes/portability/adaptability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Adaptability is the degree to which a system can effectively and efficiently be adapted for different or evolving hardware, software, or other operational or usage environments. A highly adaptable system can be moved to a new environment, reconfigured for different operational conditions, or adjusted for new platform requirements — with minimal changes to the system itself.
+Adaptability is the degree to which a system can effectively and efficiently be adapted for different or evolving hardware, software, or other operational or usage environments. A highly adaptable system can be moved to a new environment, reconfigured for different operational conditions, or adjusted for new platform requirements, with minimal changes to the system itself.
 
 ---
 
@@ -28,7 +28,7 @@ The 12-factor app principle of config states: everything that varies between dep
 
 ### Abstraction layers
 
-Adaptability is achieved by abstracting over environment-specific services behind interfaces. Code that calls a database through an interface can be adapted to a different database by providing a new implementation — without changing the calling code. Code that calls AWS S3 directly is coupled to S3.
+Adaptability is achieved by abstracting over environment-specific services behind interfaces. Code that calls a database through an interface can be adapted to a different database by providing a new implementation, without changing the calling code. Code that calls AWS S3 directly is coupled to S3.
 
 The cost of the abstraction must be weighed against the probability and cost of adaptation. Abstracting over a service that will never change is wasted complexity.
 

--- a/quality-attributes/portability/installability.md
+++ b/quality-attributes/portability/installability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Installability is the degree to which a system can be successfully installed or uninstalled in a specified environment. A system with high installability can be deployed to its target environment reliably, reproducibly, and with minimal manual intervention — and can be removed cleanly without leaving residual state.
+Installability is the degree to which a system can be successfully installed or uninstalled in a specified environment. A system with high installability can be deployed to its target environment reliably, reproducibly, and with minimal manual intervention, and can be removed cleanly without leaving residual state.
 
 ---
 
@@ -23,7 +23,7 @@ Installation dependencies (runtime versions, OS packages, network access, creden
 
 ### Clean uninstall
 
-A system with high installability can be removed completely — no orphaned processes, no residual files, no database entries that prevent reinstallation, no configuration that persists across uninstall/reinstall cycles.
+A system with high installability can be removed completely: no orphaned processes, no residual files, no database entries that prevent reinstallation, no configuration that persists across uninstall/reinstall cycles.
 
 ---
 

--- a/quality-attributes/portability/replaceability.md
+++ b/quality-attributes/portability/replaceability.md
@@ -12,7 +12,7 @@ Replaceability is relevant both at the system level (replacing one service with 
 
 ### Interface contracts as replaceability enablers
 
-A system is replaceable to the degree that its interface is well-defined and its consumers depend only on that interface — not on implementation details. If consumers use only the documented API, a replacement that honours the same contract can substitute the original without requiring consumer changes.
+A system is replaceable to the degree that its interface is well-defined and its consumers depend only on that interface, not on implementation details. If consumers use only the documented API, a replacement that honours the same contract can substitute the original without requiring consumer changes.
 
 Tight coupling to implementation details (database schemas, internal endpoints, binary wire formats, undocumented behaviours) makes replacement difficult even when the functional contract is preserved.
 

--- a/quality-attributes/reliability/availability.md
+++ b/quality-attributes/reliability/availability.md
@@ -4,7 +4,7 @@
 
 Availability is the fraction of time a system is operational and reachable by its users. It is typically expressed as a service level agreement (SLA) and has direct business consequences: downtime means users cannot complete their goals, which translates into lost revenue, broken trust, or contractual penalties.
 
-Availability is a system-level property. It is affected by every component in the request path — a chain of components is only as available as its least available link.
+Availability is a system-level property. It is affected by every component in the request path: a chain of components is only as available as its least available link.
 
 ---
 
@@ -35,18 +35,18 @@ Each additional nine is an order-of-magnitude harder to achieve. Moving from 99.
 
 Most availability strategies target one of two levers:
 
-**Increasing MTBF** — reduce how often failures occur:
+**Increasing MTBF**, reduce how often failures occur:
 - Redundant hardware and network paths
 - Rigorous testing and gradual rollouts
 - Higher-quality components
 
-**Reducing MTTR** — reduce how long recovery takes:
+**Reducing MTTR**, reduce how long recovery takes:
 - Monitoring and alerting with low detection latency
 - Automated failover
 - Runbooks and incident response procedures
 - Feature flags for rapid rollback
 
-**MTTR can be an effective lever.** Failures cannot be eliminated in complex distributed systems — hardware fails, networks partition, deployments go wrong. Recovery, however, can be automated and made predictable. A system that recovers in 30 seconds consistently is more available than one that fails rarely but takes 2 hours to restore.
+**MTTR can be an effective lever.** Failures cannot be eliminated in complex distributed systems: hardware fails, networks partition, deployments go wrong. Recovery, however, can be automated and made predictable. A system that recovers in 30 seconds consistently is more available than one that fails rarely but takes 2 hours to restore.
 
 ---
 
@@ -61,7 +61,7 @@ Most availability strategies target one of two levers:
 
 ### Availability vs. other attributes
 
-Increasing availability through redundancy adds operational complexity and cost. Active-active setups require careful consistency management — decisions about what happens when two active nodes disagree.
+Increasing availability through redundancy adds operational complexity and cost. Active-active setups require careful consistency management: decisions about what happens when two active nodes disagree.
 
 Availability targets above 99.99% typically require eliminating all single points of failure, including the load balancer, DNS, and the monitoring system itself.
 

--- a/quality-attributes/reliability/fault-tolerance.md
+++ b/quality-attributes/reliability/fault-tolerance.md
@@ -4,7 +4,7 @@
 
 Reliability describes whether a system produces correct results, even in the presence of faults. It is independent of availability: a system can be highly available (always reachable) while being unreliable (returning wrong or inconsistent results).
 
-In distributed systems, some degree of failure is inevitable. Reliability engineering is therefore not about preventing all faults — it is about building systems that tolerate faults without producing incorrect behavior.
+In distributed systems, some degree of failure is inevitable. Reliability engineering is therefore not about preventing all faults. It is about building systems that tolerate faults without producing incorrect behavior.
 
 ---
 
@@ -33,11 +33,11 @@ Fault avoidance remains important for correctness at the business logic level, b
 
 ### Idempotency
 
-An operation is idempotent if executing it multiple times produces the same result as executing it once. Idempotency is critical in any system with at-least-once delivery semantics — which includes most message queues, retry mechanisms, and distributed RPC frameworks.
+An operation is idempotent if executing it multiple times produces the same result as executing it once. Idempotency is critical in any system with at-least-once delivery semantics, which includes most message queues, retry mechanisms, and distributed RPC frameworks.
 
 Without idempotency, a retried message can cause duplicate side effects: double charges, duplicate records, repeated notifications.
 
-Idempotency requires a stable deduplication key — an identifier that is consistent across retries and unique per logical operation.
+Idempotency requires a stable deduplication key: an identifier that is consistent across retries and unique per logical operation.
 
 ---
 
@@ -60,7 +60,7 @@ This distinction is frequently misunderstood and worth stating explicitly:
 - **Availability** answers: "Is the system reachable?"
 - **Reliability** answers: "Does the system produce correct results?"
 
-A load-balanced cluster with two nodes — one returning correct results, one returning corrupted data — can have 100% availability with 50% reliability. Redundancy does not fix correctness issues; it may replicate them.
+A load-balanced cluster with two nodes, one returning correct results and one returning corrupted data, can have 100% availability with 50% reliability. Redundancy does not fix correctness issues; it may replicate them.
 
 Both properties are typically addressed independently and with separate architectural decisions.
 
@@ -81,7 +81,7 @@ Both properties are typically addressed independently and with separate architec
 
 ## Common pitfalls
 
-- **No idempotency for message consumers**: any consumer that processes messages from a queue without handling duplicates may cause incorrect behavior when messages are redelivered — which is expected under normal operating conditions in at-least-once delivery systems.
+- **No idempotency for message consumers**: any consumer that processes messages from a queue without handling duplicates may cause incorrect behavior when messages are redelivered, which is expected under normal operating conditions in at-least-once delivery systems.
 - **No stable deduplication key**: idempotency requires a key that survives retries. Using a timestamp or generated UUID per attempt defeats the purpose.
 - **Fault avoidance as the only strategy in distributed systems**: comprehensive test coverage does not address network partitions, message redelivery, or partial failures across service boundaries.
 - **Conflating reliability with availability**: adding more replicas increases availability; it does not increase reliability if the fault being replicated is a logic error or data corruption.

--- a/quality-attributes/reliability/maturity.md
+++ b/quality-attributes/reliability/maturity.md
@@ -16,7 +16,7 @@ A newly deployed system, even with good test coverage, is immature: it has not b
 
 ### Defect escape rate
 
-The primary measure of immaturity is the rate at which defects reach production. A high escape rate indicates gaps in the verification process — insufficient test coverage, missing integration scenarios, or inadequate review. Reducing escape rate is the primary lever for improving maturity.
+The primary measure of immaturity is the rate at which defects reach production. A high escape rate indicates gaps in the verification process: insufficient test coverage, missing integration scenarios, or inadequate review. Reducing escape rate is the primary lever for improving maturity.
 
 ### Software aging
 

--- a/quality-attributes/reliability/recoverability.md
+++ b/quality-attributes/reliability/recoverability.md
@@ -4,7 +4,7 @@
 
 Recoverability is the degree to which a system can recover data and re-establish its desired state in the case of an interruption or failure. It covers the restoration of lost state, the correction of corrupted data, and the resumption of processing after an outage.
 
-Availability (MTTR) measures how quickly a system returns to service. Recoverability addresses whether the system returns to the *correct* state — not just that it is reachable again.
+Availability (MTTR) measures how quickly a system returns to service. Recoverability addresses whether the system returns to the *correct* state, not just that it is reachable again.
 
 ---
 
@@ -12,7 +12,7 @@ Availability (MTTR) measures how quickly a system returns to service. Recoverabi
 
 ### Recoverability vs. availability
 
-A system can recover to an available state (reachable, responding) without being in a correct state (consistent data, no lost transactions). Recoverability ensures that after a failure, the system's state accurately reflects what happened before the failure — with no lost writes, no corrupted records, and no inconsistent views across components.
+A system can recover to an available state (reachable, responding) without being in a correct state (consistent data, no lost transactions). Recoverability ensures that after a failure, the system's state accurately reflects what happened before the failure, with no lost writes, no corrupted records, and no inconsistent views across components.
 
 ### Recovery Point Objective (RPO) and Recovery Time Objective (RTO)
 
@@ -62,5 +62,5 @@ RPO and RTO are generally defined before choosing a recovery strategy. A 0 RPO (
 
 - **Untested recovery procedures**: backup and restore processes that are never exercised tend to fail at the worst moment. Regular testing of recovery procedures reduces this risk.
 - **RPO/RTO undefined until after an incident**: without defined targets, recovery architecture lacks a concrete basis. Defining targets before designing the system allows recovery mechanisms to be matched to actual requirements.
-- **Conflating availability with recoverability**: a system that comes back online after a failure but with 2 hours of lost transactions has poor recoverability — regardless of how fast it recovered availability.
+- **Conflating availability with recoverability**: a system that comes back online after a failure but with 2 hours of lost transactions has poor recoverability, regardless of how fast it recovered availability.
 - **No data integrity checks post-recovery**: returning to service without verifying state consistency can propagate corruption silently.

--- a/quality-attributes/security/accountability.md
+++ b/quality-attributes/security/accountability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Accountability is the degree to which the actions of an entity can be traced uniquely to that entity. A system with high accountability makes it possible to determine who performed what action, when, and on which resource — for any action of significance.
+Accountability is the degree to which the actions of an entity can be traced uniquely to that entity. A system with high accountability makes it possible to determine who performed what action, when, and on which resource, for any action of significance.
 
 Accountability is a foundation for security incident response, compliance auditing, and detection of misuse. Without it, breaches and policy violations cannot be investigated effectively.
 
@@ -12,7 +12,7 @@ Accountability is a foundation for security incident response, compliance auditi
 
 ### Identity binding
 
-Accountability requires that every significant action is bound to an authenticated identity — not just a session, IP address, or service name. This means:
+Accountability requires that every significant action is bound to an authenticated identity, not just a session, IP address, or service name. This means:
 - Human actions are attributed to individual user accounts, not shared credentials
 - Service-to-service calls are attributed to specific service identities (not a single shared API key)
 - Actions taken on behalf of a user (by a background job or service) retain the original user identity in the audit trail

--- a/quality-attributes/security/authenticity.md
+++ b/quality-attributes/security/authenticity.md
@@ -14,15 +14,15 @@ Without authenticity, a system cannot make access decisions or trust the data it
 
 | Factor type | Example | Strength |
 |---|---|---|
-| Something you know | Password, PIN | Low — can be guessed, stolen, or phished |
-| Something you have | TOTP token, hardware key, SMS code | Medium-High — requires physical access or SIM swap |
-| Something you are | Biometric | High — difficult to replicate; privacy implications |
+| Something you know | Password, PIN | Low: can be guessed, stolen, or phished |
+| Something you have | TOTP token, hardware key, SMS code | Medium-High: requires physical access or SIM swap |
+| Something you are | Biometric | High: difficult to replicate; privacy implications |
 
 Multi-factor authentication (MFA) combines factors. Systems handling sensitive data or privileged access commonly require at minimum two factors.
 
 ### Service authenticity
 
-In distributed systems, services must authenticate to each other — not just users to services. Mechanisms:
+In distributed systems, services must authenticate to each other, not just users to services. Mechanisms:
 - **Mutual TLS (mTLS)**: both parties present certificates; identity is verified on both sides
 - **Short-lived service tokens (JWT, SPIFFE/SPIRE)**: services obtain tokens with a bounded lifetime; compromise has limited blast radius
 - **API keys**: simpler but long-lived; rotation is operationally complex

--- a/quality-attributes/security/confidentiality.md
+++ b/quality-attributes/security/confidentiality.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Confidentiality is the degree to which a system ensures that data is accessible only to those authorised to access it. Confidentiality failures expose data to unauthorised parties — whether through direct access, interception, or inference.
+Confidentiality is the degree to which a system ensures that data is accessible only to those authorised to access it. Confidentiality failures expose data to unauthorised parties, whether through direct access, interception, or inference.
 
 ---
 
@@ -24,7 +24,7 @@ Not all data requires the same level of confidentiality protection. A classifica
 Encryption is a primary technical control for confidentiality:
 - **In transit**: TLS for all network communication, including internal service-to-service traffic
 - **At rest**: encrypted storage for sensitive data; field-level encryption for the most sensitive fields
-- **Key management**: encryption is only as strong as key management — keys must be rotated, protected, and revocable
+- **Key management**: encryption is only as strong as key management, so keys must be rotated, protected, and revocable
 
 ### Access control
 

--- a/quality-attributes/security/integrity.md
+++ b/quality-attributes/security/integrity.md
@@ -4,7 +4,7 @@
 
 Integrity is the degree to which a system prevents unauthorised access to, or modification of, computer programs or data. It covers both deliberate tampering (malicious modification) and accidental corruption (storage errors, partial writes, transmission errors).
 
-A system with high integrity ensures that data and software match their expected state — and that any modification is authorised, complete, and detectable.
+A system with high integrity ensures that data and software match their expected state, and that any modification is authorised, complete, and detectable.
 
 ---
 

--- a/quality-attributes/security/non-repudiation.md
+++ b/quality-attributes/security/non-repudiation.md
@@ -4,7 +4,7 @@
 
 Non-repudiation is the degree to which actions or events can be proven to have taken place, such that the events or actions cannot be repudiated later. It ensures that a party that performed an action cannot later credibly deny having performed it.
 
-Non-repudiation is architecturally relevant in any system where the origin or occurrence of actions must be provable — financial transactions, legal document signing, audit-sensitive operations, and regulated workflows.
+Non-repudiation is architecturally relevant in any system where the origin or occurrence of actions must be provable: financial transactions, legal document signing, audit-sensitive operations, and regulated workflows.
 
 ---
 

--- a/quality-attributes/usability/accessibility.md
+++ b/quality-attributes/usability/accessibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Accessibility is the degree to which a system can be used by people with the widest range of characteristics and capabilities. This includes users with visual, auditory, motor, or cognitive impairments — as well as users on assistive technologies such as screen readers, switch access devices, or voice control.
+Accessibility is the degree to which a system can be used by people with the widest range of characteristics and capabilities. This includes users with visual, auditory, motor, or cognitive impairments, as well as users on assistive technologies such as screen readers, switch access devices, or voice control.
 
 Accessibility is an important design consideration and, in many contexts, a legal requirement (WCAG 2.1, EN 301 549, ADA, EAA). Architecturally, treating it as a first-class design constraint rather than a post-launch checklist reduces remediation cost.
 
@@ -53,7 +53,7 @@ Accessibility extends to developer-facing interfaces: CLIs must work with screen
 
 - Public-facing systems subject to accessibility legislation.
 - Systems used in contexts with diverse user populations.
-- Government, education, healthcare, and financial services — where accessibility requirements are typically mandated.
+- Government, education, healthcare, and financial services, where accessibility requirements are typically mandated.
 
 ## Common pitfalls
 

--- a/quality-attributes/usability/appropriateness-recognisability.md
+++ b/quality-attributes/usability/appropriateness-recognisability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Appropriateness recognisability is the degree to which users can recognise whether a system or component is appropriate for their needs. Users should be able to determine — before investing significant time — whether the system will help them accomplish their goal.
+Appropriateness recognisability is the degree to which users can recognise whether a system or component is appropriate for their needs. Users should be able to determine, before investing significant time, whether the system will help them accomplish their goal.
 
 Recognisability failures cause high abandonment rates, misuse, and support load from users who engaged with the wrong tool for their task.
 
@@ -20,7 +20,7 @@ Users assess appropriateness through: explicit purpose statements, visible examp
 
 ### Developer-facing recognisability
 
-For APIs and SDKs, recognisability means developers can determine from documentation, naming, and examples whether the interface solves their problem — before writing any code. An API that requires deep exploration to understand its scope has poor recognisability.
+For APIs and SDKs, recognisability means developers can determine from documentation, naming, and examples whether the interface solves their problem, before writing any code. An API that requires deep exploration to understand its scope has poor recognisability.
 
 ---
 

--- a/quality-attributes/usability/operability.md
+++ b/quality-attributes/usability/operability.md
@@ -32,7 +32,7 @@ Operability treats system operators (SREs, DevOps engineers) as users with speci
 |---|---|---|
 | Structured logging | Machine-parseable; queryable at scale | More verbose; higher storage cost |
 | Externalized configuration | Operational changes without redeployment | Configuration sprawl; requires a configuration management strategy |
-| Health and readiness endpoints | Enables automation and load balancer integration | Requires accurate health logic — false positives cause unnecessary restarts |
+| Health and readiness endpoints | Enables automation and load balancer integration | Requires accurate health logic: false positives cause unnecessary restarts |
 | Admin API for runtime control | Operators can adjust behaviour without deployment | Security surface; requires authentication and authorisation |
 
 ---

--- a/quality-attributes/usability/user-interface-aesthetics.md
+++ b/quality-attributes/usability/user-interface-aesthetics.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-User interface aesthetics is the degree to which a user interface enables pleasing and satisfying interaction. Aesthetics in this context is not superficial decoration — it directly affects usability: visual hierarchy guides attention, spacing reduces cognitive load, and consistent visual language reduces learning effort.
+User interface aesthetics is the degree to which a user interface enables pleasing and satisfying interaction. Aesthetics in this context is not superficial decoration. It directly affects usability: visual hierarchy guides attention, spacing reduces cognitive load, and consistent visual language reduces learning effort.
 
 From an architectural perspective, aesthetics is a concern because design systems, component libraries, and layout frameworks are architectural decisions with long-term consequences for consistency and maintainability.
 
@@ -26,7 +26,7 @@ A design system is the architectural mechanism for achieving aesthetic consisten
 
 ### Aesthetic consistency vs. brand differentiation
 
-Aesthetic consistency means applying the same visual language throughout the system. Brand differentiation means the system has a distinctive visual identity. These are compatible — but brand differentiation at the cost of internal consistency can undermine the aesthetic quality of the system.
+Aesthetic consistency means applying the same visual language throughout the system. Brand differentiation means the system has a distinctive visual identity. These are compatible, but brand differentiation at the cost of internal consistency can undermine the aesthetic quality of the system.
 
 ---
 

--- a/system-design/api-design.md
+++ b/system-design/api-design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-An API is a contract between a system and its consumers. Once an API is published, consumers couple to its exact shape — every field name, status code, and error format becomes part of the interface they depend on. Changing a published contract is therefore costly in a way that changing internal code is not: internal code can be refactored freely, while a contract change can break consumers the system does not control.
+An API is a contract between a system and its consumers. Once an API is published, consumers couple to its exact shape: every field name, status code, and error format becomes part of the interface they depend on. Changing a published contract is therefore costly in a way that changing internal code is not: internal code can be refactored freely, while a contract change can break consumers the system does not control.
 
 API design is an architectural concern rather than an implementation detail, because the exposed boundary determines how independently a system and its consumers can evolve. An API that hides internal change behind a stable surface allows both sides to change separately; one that exposes implementation details ties the internals to every consumer.
 
@@ -12,7 +12,7 @@ Contracts, versioning, error models, pagination, and idempotency are the design 
 
 ## Contracts first
 
-Contract-first design defines the contract — resource shapes, field names, status codes — before the implementation. When the contract is derived from the database schema, every consumer becomes coupled to the storage model, and each schema migration turns into a breaking change. A contract derived from consumer needs keeps storage changes internal.
+Contract-first design defines the contract (resource shapes, field names, status codes) before the implementation. When the contract is derived from the database schema, every consumer becomes coupled to the storage model, and each schema migration turns into a breaking change. A contract derived from consumer needs keeps storage changes internal.
 
 Two practices support contract stability:
 
@@ -105,7 +105,7 @@ Idempotency at the API boundary is the same problem as at-least-once delivery in
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Decision | Benefit | Cost |
 |---|---|---|
@@ -121,7 +121,7 @@ Idempotency at the API boundary is the same problem as at-least-once delivery in
 
 - **Exposing the database schema as the API.** Couples every consumer to the storage model, so any migration becomes a breaking change.
 - **`200 OK` with an error in the body.** Defeats standard HTTP error handling and forces defensive body parsing on every client.
-- **No pagination on a growing collection.** Works in development, then returns a multi-megabyte payload — or times out — once the table is large in production.
+- **No pagination on a growing collection.** Works in development, then returns a multi-megabyte payload, or times out, once the table is large in production.
 - **Breaking changes without a version bump.** Renaming or removing a field without a new version breaks every client that depended on it, often silently.
 - **Unprotected non-idempotent retries.** No idempotency key on creation endpoints means a single network timeout can double-charge, double-book, or double-send.
 - **Leaking internals in error responses.** Stack traces and SQL in error bodies are an information-disclosure vulnerability, not only an aesthetic problem.

--- a/system-design/api-styles.md
+++ b/system-design/api-styles.md
@@ -17,7 +17,7 @@ An API style is the model and protocol through which a system exposes its capabi
 ---
 
 ## REST
-REST models a system as resources addressed by URLs and manipulated with HTTP methods. It relies on standard HTTP semantics — status codes, caching, content negotiation — which gives it broad tooling and client support. A known limitation is over-fetching and under-fetching: a fixed resource shape often returns more or less than a given client needs, sometimes requiring multiple round trips.
+REST models a system as resources addressed by URLs and manipulated with HTTP methods. It relies on standard HTTP semantics (status codes, caching, content negotiation), which gives it broad tooling and client support. A known limitation is over-fetching and under-fetching: a fixed resource shape often returns more or less than a given client needs, sometimes requiring multiple round trips.
 
 ## GraphQL
 GraphQL exposes a single endpoint and a schema; clients specify exactly which fields they need in a query. This addresses over- and under-fetching and suits clients with differing data requirements. The trade-offs are that URL-level HTTP caching no longer applies, query cost can be hard to bound (one query may fan out into many resolver calls), and the server must guard against expensive or deeply nested queries.
@@ -40,7 +40,7 @@ flowchart TD
 
 ---
 
-## Decision considerations / trade-offs
+## Trade-offs
 
 | | Pro | Con |
 |---|---|---|

--- a/system-design/caching.md
+++ b/system-design/caching.md
@@ -4,7 +4,7 @@
 
 A cache stores a copy of data in a faster medium or closer to where it is used, so that repeat reads avoid the cost of recomputing or refetching from the source of truth. Caching trades freshness and memory for latency and load: the cached copy can be staler than the source and it consumes memory, in exchange for faster reads and fewer requests to the backing store.
 
-A cache is a second copy of data, so it raises the same problem as any replica — the copy and the source can disagree. Most of the difficulty in caching is keeping that disagreement within acceptable bounds. See [Consistency Models](consistency-models.md).
+A cache is a second copy of data, so it raises the same problem as any replica: the copy and the source can disagree. Most of the difficulty in caching is keeping that disagreement within acceptable bounds. See [Consistency Models](consistency-models.md).
 
 ---
 
@@ -38,7 +38,7 @@ def get_user(user_id):
 A cached entry is removed or refreshed in one of two ways:
 
 - **TTL (time to live):** the entry expires after a fixed time. It needs no coordination with writes and bounds staleness to the TTL; the cost is staleness up to the TTL and a refetch on every expiry.
-- **Explicit invalidation:** a write to the source removes or updates the cached entry. It keeps the cache fresh, but the write path must know every cache key affected — a missed key serves stale data indefinitely.
+- **Explicit invalidation:** a write to the source removes or updates the cached entry. It keeps the cache fresh, but the write path must know every cache key affected, and a missed key serves stale data indefinitely.
 
 These name the two hard problems directly: invalidation is hard because the writer must locate every dependent key, and eviction under memory pressure (LRU, LFU) can remove entries the system still needs.
 
@@ -46,7 +46,7 @@ These name the two hard problems directly: invalidation is hard because the writ
 
 ## Stampede
 
-When a popular entry expires, every concurrent request misses at once and hits the source at the same time, which can overload it — a cache stampede (or thundering herd).
+When a popular entry expires, every concurrent request misses at once and hits the source at the same time, which can overload it: a cache stampede (or thundering herd).
 
 ```mermaid
 flowchart TB
@@ -65,7 +65,7 @@ Mitigations:
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Decision | Benefit | Cost |
 |---|---|---|

--- a/system-design/consistency-models.md
+++ b/system-design/consistency-models.md
@@ -10,7 +10,7 @@ A consistency model defines what a system guarantees about the values a read can
 
 | Model | Guarantee | Consequence |
 |---|---|---|
-| Strong (linearizable) | Every read returns the most recent committed write | Requires coordination across replicas — higher latency, reduced availability under partition |
+| Strong (linearizable) | Every read returns the most recent committed write | Requires coordination across replicas: higher latency and reduced availability under partition |
 | Causal | Reads respect cause-and-effect order; related writes are seen in order | Concurrent, unrelated writes may be seen in different orders |
 | Eventual | Replicas converge to the same value once writes stop | A read may return stale data until convergence |
 
@@ -33,7 +33,7 @@ When there is no partition, the trade-off does not apply. PACELC extends CAP to 
 
 Beyond global models, systems offer guarantees scoped to a single client's view. These are weaker than strong consistency but cover the cases users notice:
 
-- **Read-your-writes:** a client always sees its own prior writes — a user sees the comment they just posted.
+- **Read-your-writes:** a client always sees its own prior writes, so a user sees the comment they just posted.
 - **Monotonic reads:** a client never sees data move backwards in time across successive reads.
 - **Consistent prefix:** a client sees writes in an order that could have occurred, never a later write without an earlier one it depends on.
 
@@ -45,13 +45,13 @@ A common implementation routes a client's reads to the replica that served its w
 
 Eventual consistency is not an abstract concept; it shows up wherever a system holds more than one copy of data:
 
-- Read replicas lag the leader, so reads from a replica are eventually consistent — see [Data Architecture](data-architecture.md#replication).
-- A saga leaves the system in intermediate states until all steps complete, producing eventual consistency across services — see [Distributed Transactions](distributed-transactions.md#saga).
-- A cache holds a copy that can be staler than its source — see [Caching](caching.md).
+- Read replicas lag the leader, so reads from a replica are eventually consistent; see [Data Architecture](data-architecture.md#replication).
+- A saga leaves the system in intermediate states until all steps complete, producing eventual consistency across services; see [Distributed Transactions](distributed-transactions.md#saga).
+- A cache holds a copy that can be staler than its source; see [Caching](caching.md).
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Decision | Benefit | Cost |
 |---|---|---|
@@ -67,4 +67,4 @@ Eventual consistency is not an abstract concept; it shows up wherever a system h
 - **Assuming strong consistency by default.** Many distributed stores are eventually consistent unless configured otherwise; the guarantee has to be checked, not assumed.
 - **Ignoring replication lag in the UI.** A user who does not immediately see their own action assumes it failed and retries.
 - **Treating "eventual" as "soon".** Convergence time is unbounded under load or partition; code cannot rely on a tight window.
-- **Concurrent conflicting writes with no resolution policy.** Multi-leader and leaderless setups need an explicit strategy — last-write-wins, CRDTs, or application-level merge.
+- **Concurrent conflicting writes with no resolution policy.** Multi-leader and leaderless setups need an explicit strategy: last-write-wins, CRDTs, or application-level merge.

--- a/system-design/cqrs-event-sourcing.md
+++ b/system-design/cqrs-event-sourcing.md
@@ -6,7 +6,7 @@ CQRS (Command Query Responsibility Segregation) and Event Sourcing are two disti
 ---
 
 ## CQRS
-In a CRUD model, one model handles both reads and writes. CQRS splits these into a **command side** — which validates and applies state changes through domain logic — and a **query side** — which serves reads from models shaped for querying.
+In a CRUD model, one model handles both reads and writes. CQRS splits these into a **command side**, which validates and applies state changes through domain logic, and a **query side**, which serves reads from models shaped for querying.
 
 ```mermaid
 flowchart LR
@@ -16,9 +16,9 @@ flowchart LR
   Q["Query"] --> RM
 ```
 
-The read model is derived from the write model, often denormalised for the specific shapes a client queries. The two are usually kept in sync asynchronously, which means a read may briefly lag a write — an explicit case of eventual consistency (see [Consistency Models](consistency-models.md)).
+The read model is derived from the write model, often denormalised for the specific shapes a client queries. The two are usually kept in sync asynchronously, which means a read may briefly lag a write: an explicit case of eventual consistency (see [Consistency Models](consistency-models.md)).
 
-CQRS is applied where read and write workloads differ enough to justify separate models — for example, when reads and writes scale independently (see [Capacity](../quality-attributes/performance-efficiency/capacity.md)), or when read shapes are complex enough that one model cannot serve both well.
+CQRS is applied where read and write workloads differ enough to justify separate models, for example when reads and writes scale independently (see [Capacity](../quality-attributes/performance-efficiency/capacity.md)), or when read shapes are complex enough that one model cannot serve both well.
 
 ---
 
@@ -42,7 +42,7 @@ Event sourcing emits a stream of events as state changes; CQRS needs a mechanism
 
 ---
 
-## Decision considerations / trade-offs
+## Trade-offs
 
 | | Pro | Con |
 |---|---|---|

--- a/system-design/data-architecture.md
+++ b/system-design/data-architecture.md
@@ -46,7 +46,7 @@ Each step stays compatible with the code running before and after it. This is th
 
 ## Indexing
 
-An index is a secondary data structure that speeds up reads matching a query, at the cost of extra storage and slower writes — the index is updated on every insert, update, or delete.
+An index is a secondary data structure that speeds up reads matching a query, at the cost of extra storage and slower writes, because the index is updated on every insert, update, or delete.
 
 ```sql
 -- Without an index, this scans every row.
@@ -57,14 +57,14 @@ CREATE INDEX idx_orders_customer ON orders (customer_id);
 ```
 
 - An index helps queries that filter or sort on the indexed columns and does nothing for queries on other columns.
-- A composite index on `(a, b)` supports queries on `a` and on `(a, b)`, but not on `b` alone — the leftmost-prefix rule.
+- A composite index on `(a, b)` supports queries on `a` and on `(a, b)`, but not on `b` alone, by the leftmost-prefix rule.
 - Each index adds write cost and storage. An index that no query uses is pure overhead.
 
 ---
 
 ## Replication
 
-Replication keeps copies of data on more than one node. It serves two goals: availability — a replica takes over if the primary fails — and read scalability, by spreading reads across replicas.
+Replication keeps copies of data on more than one node. It serves two goals: availability (a replica takes over if the primary fails) and read scalability, by spreading reads across replicas.
 
 | Model | How it works | Trade-off |
 |---|---|---|
@@ -72,11 +72,11 @@ Replication keeps copies of data on more than one node. It serves two goals: ava
 | Multi-leader | Several nodes accept writes and replicate to each other | Writes survive a node loss; write conflicts must be resolved |
 | Leaderless | Any replica accepts reads and writes, quorums reconcile | High availability; the application handles consistency (quorums, read-repair) |
 
-Replication is asynchronous by default, so followers lag behind the leader. A read served by a lagging follower can return stale data — an instance of eventual consistency, see [Consistency Models](consistency-models.md). Replication copies the whole dataset to each node; splitting the dataset across nodes for scale is *sharding*, covered in [Scalability](scalability.md#sharding-partitioning).
+Replication is asynchronous by default, so followers lag behind the leader. A read served by a lagging follower can return stale data, an instance of eventual consistency, see [Consistency Models](consistency-models.md). Replication copies the whole dataset to each node; splitting the dataset across nodes for scale is *sharding*, covered in [Scalability](scalability.md#sharding-partitioning).
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Decision | Benefit | Cost |
 |---|---|---|

--- a/system-design/distributed-transactions.md
+++ b/system-design/distributed-transactions.md
@@ -28,15 +28,15 @@ sequenceDiagram
 1. **Prepare:** the coordinator asks every participant to prepare and lock the change.
 2. **Commit:** if all vote yes, the coordinator tells everyone to commit; if any votes no, everyone rolls back.
 
-2PC provides strong consistency but blocks: participants hold locks until the coordinator decides, and if the coordinator fails after the prepare phase, participants are left holding locks — the blocking problem. This coupling and locking make 2PC ill-suited to independently deployed services communicating over unreliable networks.
+2PC provides strong consistency but blocks: participants hold locks until the coordinator decides, and if the coordinator fails after the prepare phase, participants are left holding locks, the blocking problem. This coupling and locking make 2PC ill-suited to independently deployed services communicating over unreliable networks.
 
 ---
 
 ## Saga
 
-A saga models a distributed transaction as a sequence of local transactions, one per service. Each step commits locally and emits an event or sends a command that triggers the next step. There is no global lock, and consistency is eventual — see [Consistency Models](consistency-models.md).
+A saga models a distributed transaction as a sequence of local transactions, one per service. Each step commits locally and emits an event or sends a command that triggers the next step. There is no global lock, and consistency is eventual; see [Consistency Models](consistency-models.md).
 
-When a step fails, earlier steps are undone by **compensating actions**: operations that semantically reverse a completed step. A refund compensates a charge — there is no rollback once a local transaction has committed, only a new transaction that reverses its effect.
+When a step fails, earlier steps are undone by **compensating actions**: operations that semantically reverse a completed step. A refund compensates a charge. There is no rollback once a local transaction has committed, only a new transaction that reverses its effect.
 
 ```mermaid
 flowchart LR
@@ -55,9 +55,9 @@ Sagas are coordinated in one of two styles:
 
 ## Outbox pattern
 
-A service that must update its database and publish an event faces a *dual-write* problem: the database and the message broker are two separate systems, and a crash between the two writes leaves them out of sync — the event is lost, or it is published for a change that rolled back.
+A service that must update its database and publish an event faces a *dual-write* problem: the database and the message broker are two separate systems, and a crash between the two writes leaves them out of sync: the event is lost, or it is published for a change that rolled back.
 
-The outbox pattern makes the two atomic. The event is written to an outbox table in the same local transaction as the data change. A separate relay process reads the outbox and publishes the events, retrying until each is delivered — at-least-once, so consumers must be idempotent (see [Messaging](messaging.md#delivery-guarantees)).
+The outbox pattern makes the two atomic. The event is written to an outbox table in the same local transaction as the data change. A separate relay process reads the outbox and publishes the events, retrying until each is delivered: at-least-once, so consumers must be idempotent (see [Messaging](messaging.md#delivery-guarantees)).
 
 ```python
 # One local transaction commits the domain change and the event together.
@@ -70,11 +70,11 @@ def place_order(order):
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Approach | Consistency | Cost |
 |---|---|---|
-| 2PC | Strong — atomic across participants | Blocking locks; coordinator is a failure point; poor fit across services |
+| 2PC | Strong: atomic across participants | Blocking locks; coordinator is a failure point; poor fit across services |
 | Saga | Eventual | A compensating action for every step; intermediate states are visible |
 | Outbox | Reliable event publishing, atomic with the write | An extra table and relay process; at-least-once delivery |
 
@@ -86,4 +86,4 @@ def place_order(order):
 - **Sagas without compensating actions.** A failure mid-saga leaves the system in a permanently inconsistent state.
 - **Dual writes to a database and a broker.** Without the outbox pattern, a crash between the two writes loses events or publishes phantom ones.
 - **Ignoring intermediate states.** A saga is observable mid-flight; reads and the UI must tolerate an order that is paid but not yet shipped.
-- **Assuming compensation fully reverses an effect.** Some actions — a sent email, a shipped package — cannot be undone, only mitigated.
+- **Assuming compensation fully reverses an effect.** Some actions, such as a sent email or a shipped package, cannot be undone, only mitigated.

--- a/system-design/index.md
+++ b/system-design/index.md
@@ -2,24 +2,24 @@
 
 ## Overview
 
-System design concerns the decisions that shape how a system behaves under real load and failure: how it exposes its boundary, stores its state, stays consistent across copies, moves data between its parts, and grows with demand. These concerns cut across architecture styles — a layered monolith and a microservices system both decide how to store data, when to cache, and what consistency a read guarantees.
+System design concerns the decisions that shape how a system behaves under real load and failure: how it exposes its boundary, stores its state, stays consistent across copies, moves data between its parts, and grows with demand. These concerns cut across architecture styles, since a layered monolith and a microservices system both decide how to store data, when to cache, and what consistency a read guarantees.
 
-The pages below treat each concern on its own, but the decisions are linked: a choice in one — replicating data for scale, say — constrains the options in another, such as the consistency a read can offer.
+The pages below treat each concern on its own, but the decisions are linked: a choice in one (replicating data for scale, say) constrains the options in another, such as the consistency a read can offer.
 
 ## Topics
 
 | Topic | Concern |
 |---|---|
-| [API Design](api-design.md) | The contract between a system and its consumers — versioning, error models, pagination, idempotency |
-| [API Styles](api-styles.md) | The model and protocol a system exposes — REST, GraphQL, gRPC, WebSocket, SSE |
-| [Data Architecture](data-architecture.md) | How persistent state is stored and structured — relational vs non-relational, schema evolution, indexing, replication |
-| [Consistency Models](consistency-models.md) | What a read guarantees when data is replicated or accessed concurrently — strong, causal, eventual; CAP and PACELC |
+| [API Design](api-design.md) | The contract between a system and its consumers: versioning, error models, pagination, idempotency |
+| [API Styles](api-styles.md) | The model and protocol a system exposes: REST, GraphQL, gRPC, WebSocket, SSE |
+| [Data Architecture](data-architecture.md) | How persistent state is stored and structured: relational vs non-relational, schema evolution, indexing, replication |
+| [Consistency Models](consistency-models.md) | What a read guarantees when data is replicated or accessed concurrently: strong, causal, eventual; CAP and PACELC |
 | [CQRS and Event Sourcing](cqrs-event-sourcing.md) | Separating read and write models, and storing state as a sequence of events |
-| [Messaging](messaging.md) | Asynchronous transport between components — queues vs streams, ordering, delivery guarantees |
-| [Caching](caching.md) | Copies kept closer to use for faster reads — strategies, expiry, invalidation, stampede |
-| [Scalability](scalability.md) | Handling increased load by adding resources — vertical and horizontal scaling, statelessness, sharding |
-| [Distributed Transactions](distributed-transactions.md) | Consistency across service and database boundaries — 2PC, sagas, outbox, compensation |
-| [Resilience](resilience.md) | Containing dependency failures so they do not cascade — timeout, retry, circuit breaker, bulkhead, backpressure |
+| [Messaging](messaging.md) | Asynchronous transport between components: queues vs streams, ordering, delivery guarantees |
+| [Caching](caching.md) | Copies kept closer to use for faster reads: strategies, expiry, invalidation, stampede |
+| [Scalability](scalability.md) | Handling increased load by adding resources: vertical and horizontal scaling, statelessness, sharding |
+| [Distributed Transactions](distributed-transactions.md) | Consistency across service and database boundaries: 2PC, sagas, outbox, compensation |
+| [Resilience](resilience.md) | Containing dependency failures so they do not cascade: timeout, retry, circuit breaker, bulkhead, backpressure |
 
 ## How these topics connect
 
@@ -27,6 +27,6 @@ The pages below treat each concern on its own, but the decisions are linked: a c
 - **Statelessness moves the bottleneck to data.** Keeping the service tier stateless ([Scalability](scalability.md#statelessness)) concentrates state in the data tier, so scaling compute shifts the limit onto [Data Architecture](data-architecture.md).
 - **Splitting data ownership forces distributed coordination.** Once data is partitioned across services or shards, an operation that spans them relies on [Messaging](messaging.md) and [Distributed Transactions](distributed-transactions.md) instead of a single local transaction.
 - **Idempotency recurs at every boundary.** The same duplicate-collapsing problem appears at the [API boundary](api-design.md#idempotency), in [message delivery](messaging.md#delivery-guarantees), in the outbox relay, and wherever a [retry](resilience.md#timeouts-and-retries) re-attempts a failed call: a repeated request may carry the same intent more than once, and the receiver collapses the duplicates.
-- **Style and contract are separate API decisions.** Which model and protocol a system exposes ([API Styles](api-styles.md)) is decided independently of the contract concerns — versioning, errors, pagination, idempotency — that apply to any style ([API Design](api-design.md)). Where a call needs no immediate response, [Messaging](messaging.md) is an alternative to a request/response style altogether.
-- **Event logs are a source for read models.** [Event Sourcing](cqrs-event-sourcing.md) stores state as an append-only log; projecting that log builds the read side that [CQRS](cqrs-event-sourcing.md) serves queries from — the same projection mechanism [Event-Driven Architecture](../architecture-patterns/event-driven.md#patterns-commonly-used-with-eda) uses. Because the read model trails the log, the two are linked by [eventual consistency](consistency-models.md).
-- **Scaling and resilience approach load from two sides.** Rate limiting and backpressure ([Resilience](resilience.md)) bound the load a tier accepts, while horizontal scaling ([Scalability](scalability.md)) adds capacity to serve it — one limits demand, the other increases supply.
+- **Style and contract are separate API decisions.** Which model and protocol a system exposes ([API Styles](api-styles.md)) is decided independently of the contract concerns (versioning, errors, pagination, idempotency) that apply to any style ([API Design](api-design.md)). Where a call needs no immediate response, [Messaging](messaging.md) is an alternative to a request/response style altogether.
+- **Event logs are a source for read models.** [Event Sourcing](cqrs-event-sourcing.md) stores state as an append-only log; projecting that log builds the read side that [CQRS](cqrs-event-sourcing.md) serves queries from, the same projection mechanism [Event-Driven Architecture](../architecture-patterns/event-driven.md#patterns-commonly-used-with-eda) uses. Because the read model trails the log, the two are linked by [eventual consistency](consistency-models.md).
+- **Scaling and resilience approach load from two sides.** Rate limiting and backpressure ([Resilience](resilience.md)) bound the load a tier accepts, while horizontal scaling ([Scalability](scalability.md)) adds capacity to serve it: one limits demand, the other increases supply.

--- a/system-design/messaging.md
+++ b/system-design/messaging.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Messaging moves data between components asynchronously: a sender hands a message to an intermediary, and a receiver processes it later. This decouples sender and receiver in time — the receiver need not be available when the message is sent — and is the transport that event-driven systems are built on.
+Messaging moves data between components asynchronously: a sender hands a message to an intermediary, and a receiver processes it later. This decouples sender and receiver in time (the receiver need not be available when the message is sent) and is the transport that event-driven systems are built on.
 
 This page covers the transport mechanics: how messages are held, ordered, and delivered. For the architectural style built on top of messaging, see [Event-Driven Architecture](../architecture-patterns/event-driven.md).
 
@@ -33,7 +33,7 @@ flowchart LR
   P -->|key = order-2| B["Partition B\nn1 → n2 (ordered)"]
 ```
 
-A partition key that matches the unit of ordering the domain requires — per order, per account — preserves the order that matters while letting different keys scale out across partitions.
+A partition key that matches the unit of ordering the domain requires, per order or per account, preserves the order that matters while letting different keys scale out across partitions.
 
 ---
 
@@ -47,7 +47,7 @@ No transport can guarantee exactly-once *delivery* end to end, because the sende
 | At-least-once | Retry until acknowledged | Messages can be duplicated |
 | Exactly-once (effective) | At-least-once delivery plus idempotent processing | No duplicate *effects*, achieved in the application |
 
-At-least-once is the common default. "Exactly-once" in practice means at-least-once delivery combined with an idempotent consumer that discards duplicates — the same problem as [idempotency at the API boundary](api-design.md#idempotency).
+At-least-once is the common default. "Exactly-once" in practice means at-least-once delivery combined with an idempotent consumer that discards duplicates: the same problem as [idempotency at the API boundary](api-design.md#idempotency).
 
 ```python
 # Idempotent consumer: dedupe by message id, so re-delivery has no extra effect.
@@ -62,11 +62,11 @@ def handle(message):
 
 ## Failure handling
 
-A message that cannot be processed — malformed, or its downstream dependency is unavailable — blocks the consumer if it is retried forever. A dead-letter queue (DLQ) holds messages that exceed a retry limit, so the rest of the stream proceeds while the failures are inspected and replayed separately. See [Event-Driven Architecture](../architecture-patterns/event-driven.md#patterns-commonly-used-with-eda) for the DLQ and outbox patterns in the context of producing events reliably.
+A message that cannot be processed, because it is malformed or its downstream dependency is unavailable, blocks the consumer if it is retried forever. A dead-letter queue (DLQ) holds messages that exceed a retry limit, so the rest of the stream proceeds while the failures are inspected and replayed separately. See [Event-Driven Architecture](../architecture-patterns/event-driven.md#patterns-commonly-used-with-eda) for the DLQ and outbox patterns in the context of producing events reliably.
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Decision | Benefit | Cost |
 |---|---|---|

--- a/system-design/resilience.md
+++ b/system-design/resilience.md
@@ -21,7 +21,7 @@ In a distributed system, dependencies fail: networks drop packets, services slow
 ---
 
 ## Timeouts and retries
-A timeout bounds how long a caller waits before treating a call as failed, freeing resources for other work. Retries re-attempt a failed call on the assumption that the failure was transient. Retries commonly use **exponential backoff** — increasing the delay between attempts — and **jitter** — randomising the delay — so that many clients do not retry in synchronised waves.
+A timeout bounds how long a caller waits before treating a call as failed, freeing resources for other work. Retries re-attempt a failed call on the assumption that the failure was transient. Retries commonly use **exponential backoff** (increasing the delay between attempts) and **jitter** (randomising the delay) so that many clients do not retry in synchronised waves.
 
 Retries are safe only when the operation is **idempotent**: applying it more than once has the same effect as applying it once (see [API Design](api-design.md#idempotency) and [Messaging](messaging.md#delivery-guarantees)). Retrying a non-idempotent operation can duplicate side effects such as a payment.
 
@@ -59,12 +59,12 @@ stateDiagram-v2
 - **Open**: calls fail fast without reaching the dependency, giving it time to recover.
 - **Half-open**: a limited number of trial calls test whether the dependency has recovered.
 
-A circuit breaker is paired with a fallback: while the circuit is open, the caller needs a defined behaviour — a cached value, a default, or a clear error.
+A circuit breaker is paired with a fallback: while the circuit is open, the caller needs a defined behaviour: a cached value, a default, or a clear error.
 
 ---
 
 ## Isolation and load management
-- **Bulkhead**: resources such as connection or thread pools are partitioned per dependency, so one saturated dependency cannot consume all capacity — analogous to compartments in a ship's hull.
+- **Bulkhead**: resources such as connection or thread pools are partitioned per dependency, so one saturated dependency cannot consume all capacity, analogous to compartments in a ship's hull.
 - **Rate limiting**: a ceiling on accepted requests protects a system from more load than it can serve; excess is rejected (often with HTTP `429`) or delayed.
 - **Backpressure**: when a consumer cannot keep up, it signals the producer to slow down rather than buffering without bound; unbounded buffers turn an overload into memory exhaustion.
 
@@ -75,7 +75,7 @@ These patterns are layered rather than used in isolation. A typical outbound cal
 
 ---
 
-## Decision considerations / trade-offs
+## Trade-offs
 
 | | Pro | Con |
 |---|---|---|

--- a/system-design/scalability.md
+++ b/system-design/scalability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Scalability is the ability of a system to handle increased load by adding resources. A scalable system absorbs growth by adding capacity; an unscalable one reaches a ceiling that more hardware cannot raise. Load takes several forms — request rate, data volume, concurrent users — and a system can scale for one while remaining bound on another.
+Scalability is the ability of a system to handle increased load by adding resources. A scalable system absorbs growth by adding capacity; an unscalable one reaches a ceiling that more hardware cannot raise. Load takes several forms (request rate, data volume, concurrent users), and a system can scale for one while remaining bound on another.
 
 Scalability is closely related to the capacity quality attribute; see [Capacity](../quality-attributes/performance-efficiency/capacity.md).
 
@@ -12,18 +12,18 @@ Scalability is closely related to the capacity quality attribute; see [Capacity]
 
 | | Vertical (scale up) | Horizontal (scale out) |
 |---|---|---|
-| Method | A bigger machine — more CPU, RAM | More machines |
+| Method | A bigger machine: more CPU, RAM | More machines |
 | Limit | The hardware ceiling of one node | No hard ceiling; coordination cost grows |
 | Failure | A single point of failure | Redundancy across nodes |
-| Complexity | Low — no distribution | Higher — distribution, balancing, consistency |
+| Complexity | Low: no distribution | Higher: distribution, balancing, consistency |
 
-Vertical scaling is bounded by the largest available machine and keeps a single point of failure. Horizontal scaling removes that ceiling and adds redundancy, at the cost of the coordination problems distribution introduces — load balancing, shared state, and consistency.
+Vertical scaling is bounded by the largest available machine and keeps a single point of failure. Horizontal scaling removes that ceiling and adds redundancy, at the cost of the coordination problems distribution introduces: load balancing, shared state, and consistency.
 
 ---
 
 ## Statelessness
 
-Whether a service scales horizontally depends on where it keeps state. A *stateless* service holds no client-specific state between requests, so any instance can serve any request and instances can be added, removed, or replaced freely. A *stateful* service ties a client to a specific instance — for example an in-memory session — which prevents free distribution.
+Whether a service scales horizontally depends on where it keeps state. A *stateless* service holds no client-specific state between requests, so any instance can serve any request and instances can be added, removed, or replaced freely. A *stateful* service ties a client to a specific instance (for example an in-memory session), which prevents free distribution.
 
 The common pattern is to externalise state: move sessions, caches, and data to a shared store so the service tier stays stateless. State then concentrates in the data tier, which is scaled with replication and sharding.
 
@@ -42,7 +42,7 @@ flowchart TB
 A load balancer distributes incoming requests across instances, removes failed instances from rotation through health checks, and presents horizontal capacity behind a single endpoint.
 
 - Distribution algorithms include round-robin, least-connections, and hashing on a request key.
-- Sticky sessions — routing a client to the same instance — reintroduce statefulness into the service tier and limit even distribution, which removes part of the benefit of horizontal scaling.
+- Sticky sessions (routing a client to the same instance) reintroduce statefulness into the service tier and limit even distribution, which removes part of the benefit of horizontal scaling.
 
 ---
 
@@ -56,11 +56,11 @@ Replication copies the whole dataset to each node (see [Data Architecture](data-
 | Range-based | Contiguous key ranges per node | Range queries stay local; sequential keys create hotspots |
 | Directory-based | A lookup table maps key to node | Flexible; the lookup is another component to maintain |
 
-A shard key that spreads load evenly and keeps related data together avoids hotspots; a low-cardinality or sequential key concentrates load on one shard. Queries and transactions that span shards are expensive because they touch multiple nodes — see [Distributed Transactions](distributed-transactions.md).
+A shard key that spreads load evenly and keeps related data together avoids hotspots; a low-cardinality or sequential key concentrates load on one shard. Queries and transactions that span shards are expensive because they touch multiple nodes; see [Distributed Transactions](distributed-transactions.md).
 
 ---
 
-## Key trade-offs
+## Trade-offs
 
 | Decision | Benefit | Cost |
 |---|---|---|


### PR DESCRIPTION
- Standardize trade-off section headings to 'Trade-offs'
- Rename 'Practical examples' sections to 'Examples'
- Replace em-dashes in prose with colons, commas, parentheses, or sentence breaks for cleaner, more consistent style